### PR TITLE
Implemented isObjectStore for the Azure adaptor

### DIFF
--- a/osaka/storage/az.py
+++ b/osaka/storage/az.py
@@ -146,6 +146,7 @@ class Azure(osaka.base.StorageBase):
         if len(children) == 0 or (len(children) == 1 and children[0] == uri):
             return False
         return True
+    def isObjectStore(self): return True
     def close(self):
         '''
         Close this backend


### PR DESCRIPTION
Implemented the `isObjectStore` function on the Azure Blob storage adaptor to eliminate "Azure does not implement 'isObjectStore' call" exceptions. If possible, do rebuild the `hysds/pge-base` container on Docker Hub after this pull request is approved.