### PR TITLE
HC-76 Osaka HTTP Storage isComposite fails when given URL to binary file

### DIFF
--- a/osaka/storage/http.py
+++ b/osaka/storage/http.py
@@ -181,7 +181,7 @@ class HTTP(osaka.base.StorageBase):
         except StopIteration:
             first = ""
         response.close()
-        if first.startswith("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""):
+        if isinstance(first, str) and first.startswith("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""):
             osaka.utils.LOGGER.debug(
                 "Is URI {0} composite? {1}".format(uri, True))
             return True

--- a/osaka/tests/test_http.py
+++ b/osaka/tests/test_http.py
@@ -1,0 +1,16 @@
+import unittest
+
+import osaka.storage.http
+
+
+class StorageHTTPTest(unittest.TestCase):
+
+    def test_isComposite_with_binary_file(self):
+        test_url = "http://landsat-pds.s3.amazonaws.com/scene_list.gz"
+
+        storage_http = osaka.storage.http.HTTP()
+        try:
+            storage_http.connect(test_url)
+            self.assertFalse(storage_http.isComposite(test_url))
+        finally:
+            storage_http.close()


### PR DESCRIPTION
Only call `startswith` with a string parameter if the result is a string. This prevents TypeError from being thrown when the response is bytes which can happen when given a direct download link.