### PR TITLE
HC-77 TypeError when downloading binary file via HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.egg-info
 *.pyc
 .vscode

--- a/osaka/storage/file.py
+++ b/osaka/storage/file.py
@@ -1,21 +1,23 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
-from builtins import open
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from builtins import object
+from builtins import open
+
+import urllib3.response
 from future import standard_library
+
 standard_library.install_aliases()
 import urllib.parse
 import shutil
 import os
-import re
 import datetime
 import io
 
 import osaka.utils
 import osaka.base
-
 
 '''
 File handling using local moves and/or fabric 
@@ -79,7 +81,9 @@ class File(osaka.base.StorageBase):
         except Exception as e:
             osaka.utils.LOGGER.debug(
                 "Exception while creating directories {0}".format(e))
-        flags = 'wb' if isinstance(stream, io.BufferedIOBase) else 'w'
+
+        flags = 'wb' if isinstance(stream, io.BufferedIOBase) or isinstance(stream,
+                                                                            urllib3.response.HTTPResponse) else 'w'
         with open(path, flags) as out:
             shutil.copyfileobj(stream, out)
         return osaka.utils.get_disk_usage(urllib.parse.urlparse(uri).path)
@@ -133,7 +137,8 @@ class File(osaka.base.StorageBase):
             "Is URI {0} a directory: {1} {2}".format(uri, isDir, self.exists(uri)))
         return isDir
 
-    def isObjectStore(self): return False
+    def isObjectStore(self):
+        return False
 
     def close(self):
         '''
@@ -179,7 +184,7 @@ class FileHandlerConversion(object):
         if self.filename is None or not os.path.exists(self.filename):
             self.handler = File()
             self.filename = "/tmp/osaka-temporary-" + \
-                datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f")
+                            datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f")
             self.handler.connect(self.filename)
             self.handler.put(stream, self.filename)
 

--- a/osaka/storage/http.py
+++ b/osaka/storage/http.py
@@ -181,7 +181,7 @@ class HTTP(osaka.base.StorageBase):
         except StopIteration:
             first = ""
         response.close()
-        if first.startswith("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""):
+        if isinstance(first, str) and first.startswith("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""):
             osaka.utils.LOGGER.debug(
                 "Is URI {0} composite? {1}".format(uri, True))
             return True

--- a/osaka/tests/test_http.py
+++ b/osaka/tests/test_http.py
@@ -1,0 +1,16 @@
+import unittest
+
+import osaka.storage.http
+
+
+class StorageHTTPTest(unittest.TestCase):
+
+    def test_isComposite_with_binary_file(self):
+        test_url = "http://landsat-pds.s3.amazonaws.com/scene_list.gz"
+
+        storage_http = osaka.storage.http.HTTP()
+        try:
+            storage_http.connect(test_url)
+            self.assertFalse(storage_http.isComposite(test_url))
+        finally:
+            storage_http.close()

--- a/osaka/tests/test_transfer.py
+++ b/osaka/tests/test_transfer.py
@@ -1,9 +1,12 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from builtins import str
+
 from future import standard_library
+
 standard_library.install_aliases()
 import re
 import os
@@ -16,12 +19,26 @@ import osaka.tests.util
 
 # Turn off requests warning
 import requests
+
 requests.packages.urllib3.disable_warnings()
 '''
 Created on Aug 29, 2016
 
 @author: mstarch
 '''
+
+
+class SimpleTransferTest(unittest.TestCase):
+
+    def test_http_download_to_file(self):
+        source_uri = "http://landsat-pds.s3.amazonaws.com/scene_list.gz"
+        dest_uri = "scene_list.gz"
+
+        try:
+            osaka.main.transfer(source_uri, dest_uri, params={}, measure=False, output="./pge_metrics.json",
+                                lockMetadata={}, retries=0, force=False, ncoop=False, noclobber=False)
+        finally:
+            os.remove(dest_uri)
 
 
 class TransferTest(unittest.TestCase):
@@ -56,7 +73,7 @@ class TransferTest(unittest.TestCase):
         # A list of output only locations
         self.out = []
         # Construct path to checked-in test cases
-        self.base = os.path.dirname(osaka.__file__)+"/../resources/objects/"
+        self.base = os.path.dirname(osaka.__file__) + "/../resources/objects/"
         self.objects = [os.path.join(self.base, listing) for listing in os.listdir(
             self.base) if listing.startswith("test-")]
         osaka.tests.util.scpWorkerObject(self, self.objects[1])
@@ -140,6 +157,7 @@ class TransferTest(unittest.TestCase):
                 self.checkObject(os.path.join(
                     scratch, os.path.basename(remote), os.path.basename(remote)))
             osaka.main.rmall(scratch)
+
         # First run the in-out tests
         self.test_InOuts(reupload)
 
@@ -190,7 +208,8 @@ class TransferTest(unittest.TestCase):
         Checks an object in against the original object contained in the Osaka module
         @param obj - object to test (by name) against original
         '''
-        return subprocess.call(["diff", "-r", os.path.join(self.base, os.path.basename(obj), obj), obj], stdout=osaka.tests.util.DEVNULL, stderr=osaka.tests.util.DEVNULL) == 0
+        return subprocess.call(["diff", "-r", os.path.join(self.base, os.path.basename(obj), obj), obj],
+                               stdout=osaka.tests.util.DEVNULL, stderr=osaka.tests.util.DEVNULL) == 0
 
     def uploadInputObjects(self, uriBase):
         '''


### PR DESCRIPTION
Open destination file as binary file if the stream is of type `urllib3.response.HTTPResponse`. The only time stream will be of type `urllib3.response.HTTPResponse` is if `urllib3.response.HTTPResponse.raw` is returned from `osaka.storage.http.get()` (I think).

This was caused by a change from python2 to 3.