### PR TITLE
HC-23: mitigate "404 HeadObject operation: Not Found" errors in osaka caused by s3 eventual consistency 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
           name: Test
           command: |
             source $HOME/.bash_profile
+            pip install moto
             pytest .
 
 workflows:

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,20 @@
+[flake8] 
+format = pylint
+max-line-length = 120
+ignore =
+    # E203: whitespace before ':' 
+    E203,
+    # E501: line too long
+    E501,
+    # W503: line break before binary operator
+    W503,
+    # E722: do not use bare 'except'
+    E722,
+    # P101: format string does contain unindexed parameters
+    P101,
+    # P102: docstring does contain unindexed parameters
+    P102,
+    # P103: other string does contain unindexed parameters
+    P103
+statistics = 1
+tee = 1

--- a/.flake8
+++ b/.flake8
@@ -4,8 +4,12 @@ max-line-length = 120
 ignore =
     # E203: whitespace before ':' 
     E203,
+    # E402: module level import not at top of file
+    E402,
     # E501: line too long
     E501,
+    # W291: trailing whitespace
+    W291,
     # W503: line break before binary operator
     W503,
     # E722: do not use bare 'except'

--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+
 __version__ = "0.1.6"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"

--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "0.1.6"
+__version__ = "1.0.0"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"

--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"

--- a/osaka/__main__.py
+++ b/osaka/__main__.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import argparse
 import functools
@@ -15,11 +16,11 @@ import osaka.utils
 
 
 def argparse_exception_wrapper(function, arg):
-    '''
+    """
     A function wrapper that converts exceptions into an arg-parse type exception
     @param function - function to call (typically bound using functools.partial)
     @param arg - argument to check
-    '''
+    """
     try:
         function(arg)
     except Exception as e:
@@ -28,94 +29,205 @@ def argparse_exception_wrapper(function, arg):
 
 
 def get_main_parser():
-    ''' Gets the top-level parser '''
-    parser = argparse.ArgumentParser(
-        prog="osaka", description="Mosura-CLI for Osaka")
-    parser.add_argument("-v", "--verbose", help="Enables verbose output",
-                        action="store_true", default=False)
-    parser.add_argument("-d", "--debug", help="Enables debug output",
-                        action="store_true", default=False)
-    subparsers = parser.add_subparsers(help='sub-command help', dest="cmd")
+    """ Gets the top-level parser """
+    parser = argparse.ArgumentParser(prog="osaka", description="Mosura-CLI for Osaka")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Enables verbose output",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "-d", "--debug", help="Enables debug output", action="store_true", default=False
+    )
+    subparsers = parser.add_subparsers(help="sub-command help", dest="cmd")
     add_get_parser(subparsers)
     add_put_parser(subparsers)
     add_rm_parser(subparsers)
     add_size_parser(subparsers)
     add_list_parser(subparsers)
-    parser_ex = subparsers.add_parser("exists", description="Check the existence of the specified source Osaka-URL",
-                                      help="'exists' sub-command help")
-    parser_ex.add_argument("source", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                           help="The source Osaka-URL to remove")
     parser_ex = subparsers.add_parser(
-        "gojira", description="RRRRRRAAAAAAAWWW...", help="RRRRRRAAAAAAAWWW...")
+        "exists",
+        description="Check the existence of the specified source Osaka-URL",
+        help="'exists' sub-command help",
+    )
+    parser_ex.add_argument(
+        "source",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        help="The source Osaka-URL to remove",
+    )
+    parser_ex = subparsers.add_parser(
+        "gojira", description="RRRRRRAAAAAAAWWW...", help="RRRRRRAAAAAAAWWW..."
+    )
     return parser
 
 
 def add_get_parser(subparsers):
-    ''' Osaka GET command line '''
-    parser_get = subparsers.add_parser("get", description="Retrieves the specified Osaka-URL to specified destination",
-                                       help="'get' sub-command help")
+    """ Osaka GET command line """
+    parser_get = subparsers.add_parser(
+        "get",
+        description="Retrieves the specified Osaka-URL to specified destination",
+        help="'get' sub-command help",
+    )
     parser_get.add_argument(
-        "-f", "--force", help="Forces a retrieval of the source Osaka-URL", action="store_true", default=False)
-    parser_get.add_argument("-x", "--no-coop", help="Refuses to cooperate with other osaka processes",
-                            action="store_true", default=False, dest="ncoop")
-    parser_get.add_argument("-n", "--no-clobber", help="Refuses to clobber existing destinations",
-                            action="store_true", default=False, dest="noclobber")
-    parser_get.add_argument("source", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                            help="The source Osaka-URL to get")
-    parser_get.add_argument("destination", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                            nargs="?",
-                            default="./",
-                            help="The destination Osaka-URL to place result. Defaults to CWD")
+        "-f",
+        "--force",
+        help="Forces a retrieval of the source Osaka-URL",
+        action="store_true",
+        default=False,
+    )
+    parser_get.add_argument(
+        "-x",
+        "--no-coop",
+        help="Refuses to cooperate with other osaka processes",
+        action="store_true",
+        default=False,
+        dest="ncoop",
+    )
+    parser_get.add_argument(
+        "-n",
+        "--no-clobber",
+        help="Refuses to clobber existing destinations",
+        action="store_true",
+        default=False,
+        dest="noclobber",
+    )
+    parser_get.add_argument(
+        "source",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        help="The source Osaka-URL to get",
+    )
+    parser_get.add_argument(
+        "destination",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        nargs="?",
+        default="./",
+        help="The destination Osaka-URL to place result. Defaults to CWD",
+    )
 
 
 def add_put_parser(subparsers):
-    ''' Osaka PUT command line '''
-    parser_put = subparsers.add_parser("put", description="Puts the specified source Osaka-URL to specified destination Osaka-URL",
-                                       help="'put' sub-command help")
-    parser_put.add_argument("-x", "--no-coop", help="Refuses to cooperate with other osaka processes",
-                            action="store_true", default=False, dest="ncoop")
-    parser_put.add_argument("-n", "--no-clobber", help="Refuses to clobber existing destinations",
-                            action="store_true", default=False, dest="noclobber")
-    parser_put.add_argument("source", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                            help="The source Osaka-URL to put")
-    parser_put.add_argument("destination", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                            help="The destination Osaka-URL to place result")
+    """ Osaka PUT command line """
+    parser_put = subparsers.add_parser(
+        "put",
+        description="Puts the specified source Osaka-URL to specified destination Osaka-URL",
+        help="'put' sub-command help",
+    )
+    parser_put.add_argument(
+        "-x",
+        "--no-coop",
+        help="Refuses to cooperate with other osaka processes",
+        action="store_true",
+        default=False,
+        dest="ncoop",
+    )
+    parser_put.add_argument(
+        "-n",
+        "--no-clobber",
+        help="Refuses to clobber existing destinations",
+        action="store_true",
+        default=False,
+        dest="noclobber",
+    )
+    parser_put.add_argument(
+        "source",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        help="The source Osaka-URL to put",
+    )
+    parser_put.add_argument(
+        "destination",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        help="The destination Osaka-URL to place result",
+    )
 
 
 def add_rm_parser(subparsers):
-    ''' Osaka RM command line '''
-    parser_rm = subparsers.add_parser("rm", description="Remove the specified source Osaka-URL",
-                                      help="'rm' sub-command help")
-    parser_rm.add_argument("source", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                           help="The source Osaka-URL to remove")
-    parser_rm.add_argument("-f", "--force", dest="unlock",
-                           help="Force unlock before removal", action='store_true', default=False)
+    """ Osaka RM command line """
+    parser_rm = subparsers.add_parser(
+        "rm",
+        description="Remove the specified source Osaka-URL",
+        help="'rm' sub-command help",
+    )
+    parser_rm.add_argument(
+        "source",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        help="The source Osaka-URL to remove",
+    )
+    parser_rm.add_argument(
+        "-f",
+        "--force",
+        dest="unlock",
+        help="Force unlock before removal",
+        action="store_true",
+        default=False,
+    )
 
 
 def add_size_parser(subparsers):
-    ''' Osaka size command line '''
-    parser_size = subparsers.add_parser("size", description="Returns the size of the specified source Osaka-URL",
-                                        help="'size' sub-command help")
-    parser_size.add_argument("source", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                             help="The source Osaka-URL to size")
-    parser_size.add_argument("-f", "--force", dest="force",
-                             help="Force sizing for locked urls", action='store_true', default=False)
+    """ Osaka size command line """
+    parser_size = subparsers.add_parser(
+        "size",
+        description="Returns the size of the specified source Osaka-URL",
+        help="'size' sub-command help",
+    )
+    parser_size.add_argument(
+        "source",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        help="The source Osaka-URL to size",
+    )
+    parser_size.add_argument(
+        "-f",
+        "--force",
+        dest="force",
+        help="Force sizing for locked urls",
+        action="store_true",
+        default=False,
+    )
 
 
 def add_list_parser(subparsers):
-    ''' Osaka size command line '''
-    parser_ls = subparsers.add_parser("list", description="Returns the recursive listing of the specified source Osaka-URL",
-                                      help="'list' sub-command help")
-    parser_ls.add_argument("source", type=functools.partial(argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend),
-                           help="The source Osaka-URL to list children")
-    parser_ls.add_argument("-f", "--force", dest="force",
-                           help="Force sizing for locked urls", action='store_true', default=False)
+    """ Osaka size command line """
+    parser_ls = subparsers.add_parser(
+        "list",
+        description="Returns the recursive listing of the specified source Osaka-URL",
+        help="'list' sub-command help",
+    )
+    parser_ls.add_argument(
+        "source",
+        type=functools.partial(
+            argparse_exception_wrapper, osaka.base.StorageBase.getStorageBackend
+        ),
+        help="The source Osaka-URL to list children",
+    )
+    parser_ls.add_argument(
+        "-f",
+        "--force",
+        dest="force",
+        help="Force sizing for locked urls",
+        action="store_true",
+        default=False,
+    )
 
 
 def main(args=None):
-    '''
+    """
     Entry-point for the main osaka-cli
-    '''
+    """
     parsed = get_main_parser().parse_args(args)
     # Setup logging levels
     if parsed.debug:
@@ -151,8 +263,11 @@ def main(args=None):
             for listing in ret:
                 print("  {0}".format(listing))
     except Exception as e:
-        print("[ERROR] An exception of type {0} occured with message '{1}'".format(
-            type(e).__name__, e))
+        print(
+            "[ERROR] An exception of type {0} occured with message '{1}'".format(
+                type(e).__name__, e
+            )
+        )
         if parsed.debug:
             traceback.print_exc()
         return -1
@@ -160,10 +275,10 @@ def main(args=None):
 
 
 def gojira():
-    '''
+    """
     A Gojira egg
-    '''
-    moth = '''
+    """
+    moth = """
                       '####++###+++++++++++++++++#############+++++++++++++++++++#################################+'                                            
                         '############+++++++++##############++++++++++++++++++++####################################+'                                          
                           +#####++######################+++++++++++###################################################+                                         
@@ -209,12 +324,12 @@ def gojira():
                                                                                             +@                                              @#                  
                                                                                              @@                                            #@                   
 Osaka - Mosura - Special Thanks: The HySDS Team
-'''
+"""
     print(moth)
 
 
 if __name__ == "__main__":
-    '''
+    """
     Osaka CLI
-    '''
+    """
     sys.exit(main())

--- a/osaka/__main__.py
+++ b/osaka/__main__.py
@@ -7,6 +7,7 @@ from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
+import sys
 import argparse
 import functools
 import logging

--- a/osaka/base.py
+++ b/osaka/base.py
@@ -1,52 +1,52 @@
-'''
+"""
 Created on Apr 27, 2016
 
 @author: mstarch
-'''
+"""
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
+
 standard_library.install_aliases()
 import urllib.parse
 import osaka.utils
 
 
 class StorageBase(object):
-    '''
+    """
     Represents the base class for Osaka storage implementers
     including basic functions.
-    '''
+    """
 
     def __init__(self, params={}):
-        '''
+        """
         Constructor
-        '''
+        """
         self.connect(params)
 
     @classmethod
     def getStorageBackend(clazz, uri):
-        '''
+        """
         Returns a subclass instance of this class that
         can process the given URI type
         @param uri: uri for which to get a backend
-        '''
+        """
         clazz.loadBackends()
         searching = urllib.parse.urlparse(uri).scheme.rstrip("://")
         try:
             return clazz.map[searching]()
         except Exception as e:
-            err = "Failed to get backend for {0}. Reason: {1}".format(
-                searching, e)
+            err = "Failed to get backend for {0}. Reason: {1}".format(searching, e)
             osaka.utils.LOGGER.error(err)
             raise osaka.utils.OsakaException(err)
 
     @classmethod
     def loadBackends(clazz):
-        '''
+        """
         Loads the backends
-        '''
+        """
         if "map" in clazz.__dict__:
             return
         clazz.map = {}
@@ -57,92 +57,106 @@ class StorageBase(object):
         import osaka.storage.az
         import osaka.storage.gs
         import osaka.storage.ftp
+
         for cls in clazz.__subclasses__():
             types = cls.getSchemes()
             osaka.utils.LOGGER.debug(
-                "Found storage backend: {0} handling {1}".format(cls.__name__, types))
+                "Found storage backend: {0} handling {1}".format(cls.__name__, types)
+            )
             for scheme in types:
                 clazz.map[scheme] = cls
         return clazz.map
 
     def connect(self, params={}):
-        '''
+        """
         Connects to the backend
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'connection' call".format(type(self).__name__))
+            "{0} does not implement 'connection' call".format(type(self).__name__)
+        )
 
     def get(self, uri):
-        '''
+        """
         Gets the URI as a steam
         @param uri: uri to get
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'get' call".format(type(self).__name__))
+            "{0} does not implement 'get' call".format(type(self).__name__)
+        )
 
     def put(self, stream, uri):
-        '''
+        """
         Puts a stream to a URI as a steam
         @param stream: stream to upload
         @param uri: uri to put
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'put' call".format(type(self).__name__))
+            "{0} does not implement 'put' call".format(type(self).__name__)
+        )
 
     def exists(self, uri):
-        '''
+        """
         Does the URI exist?
         @param uri: uri to check
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'exists' call".format(type(self).__name__))
+            "{0} does not implement 'exists' call".format(type(self).__name__)
+        )
 
     def list(self, uri):
-        '''
+        """
         List URI
         @param uri: uri to list
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'list' call".format(type(self).__name__))
+            "{0} does not implement 'list' call".format(type(self).__name__)
+        )
 
     def isComposite(self, uri):
-        '''
+        """
         Detect if this uri is a composite uri (uri to collection of objects i.e. directory)
         @param uri: uri to list
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'isComposite' call".format(type(self).__name__))
+            "{0} does not implement 'isComposite' call".format(type(self).__name__)
+        )
 
     def isObjectStore(self):
-        '''
+        """
         Return True if backend is an object store where no directories exist. Only keys.
         @param uri: uri to list
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'isObjectStore' call".format(type(self).__name__))
+            "{0} does not implement 'isObjectStore' call".format(type(self).__name__)
+        )
 
     def close(self):
-        '''
+        """
         Close this backend
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'close' call".format(type(self).__name__))
+            "{0} does not implement 'close' call".format(type(self).__name__)
+        )
 
     def rm(self, uri):
-        '''
+        """
         Remove this uri from backend
         @param uri: uri to remove
-        '''
+        """
         raise osaka.utils.OsakaException(
-            "{0} does not implement 'rm' call".format(type(self).__name__))
+            "{0} does not implement 'rm' call".format(type(self).__name__)
+        )
 
     def listAllChildren(self, uri):
-        '''
+        """
         List all children of the current uri, including this URI if it is a non-composite
         @param uri: uri to check
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "{0} does not implement 'listAllChildren' call, attempting list-and-walk".format(type(self).__name__))
+            "{0} does not implement 'listAllChildren' call, attempting list-and-walk".format(
+                type(self).__name__
+            )
+        )
         children = []
         for entry in self.list(uri):
             if self.isComposite(entry):

--- a/osaka/cooperator.py
+++ b/osaka/cooperator.py
@@ -38,7 +38,7 @@ class Cooperator(object):
             self.dlock.lock(lockMetadata)
             self.primary = True
         except OsakaException as ose:
-            if not "Lock file already locked" in str(ose):
+            if "Lock file already locked" not in str(ose):
                 raise
             self.whenLocked()
         return self
@@ -52,7 +52,7 @@ class Cooperator(object):
         """
         if not self.primary:
             return
-        elif not exception_value is None:
+        elif exception_value is not None:
             self.dlock.setLockMetadata(
                 "error", str(exception_type) + str(exception_value)
             )
@@ -76,7 +76,7 @@ class Cooperator(object):
                     self.source, ex_source, ouri
                 )
             )
-        elif not error is None:
+        elif error is not None:
             raise OsakaException("Cooperation error for {0}: {1}".format(ouri, error))
 
     def isPrimary(self):
@@ -108,7 +108,7 @@ class Spinner(object):
         tm = 0
         while True:
             error = self.dlock.getLockMetadata("error")
-            if not error is None:
+            if error is not None:
                 raise OsakaException("Cooperation error: " + error)
             elif not self.dlock.isLocked():
                 return

--- a/osaka/cooperator.py
+++ b/osaka/cooperator.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import copy
 import time
@@ -11,25 +12,25 @@ from osaka.utils import OsakaException, CooperationNotPossibleException
 
 
 class Cooperator(object):
-    '''
+    """
     A cooperator object used to facilitate cooperation between two differen osaka instances
     @mstarch
-    '''
+    """
 
     def __init__(self, source, dlock, lockMetadata):
-        '''
+        """
         Initialize a cooperator
-        '''
+        """
         self.source = source
         self.dlock = dlock
         self.lockMetadata = lockMetadata
         self.primary = False
 
     def __enter__(self):
-        '''
+        """
         Enter this cooperate block
         @param:
-        '''
+        """
         # Atomic lock-or-cooperate depends on each backend's atomicity of "put"
         try:
             lockMetadata = copy.copy(self.lockMetadata)
@@ -43,63 +44,67 @@ class Cooperator(object):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        '''
+        """
         Handle exceptions in the with block
         @param exception_type: exception type
         @param exception_value: exception value
         @param traceback: traceback of exception
-        '''
+        """
         if not self.primary:
             return
         elif not exception_value is None:
-            self.dlock.setLockMetadata("error", str(
-                exception_type) + str(exception_value))
+            self.dlock.setLockMetadata(
+                "error", str(exception_type) + str(exception_value)
+            )
         else:
             self.dlock.unlock()
 
     def whenLocked(self):
-        '''
+        """
         What to do when a file is already locked
-        '''
+        """
         ex_source = self.dlock.getLockMetadata("source")
         error = self.dlock.getLockMetadata("error")
         ouri = self.dlock.ouri
         if ex_source is None:
-            raise CooperationNotPossibleException("No source specified. Cooperation not possible for {0}"
-                                                  .format(ouri))
+            raise CooperationNotPossibleException(
+                "No source specified. Cooperation not possible for {0}".format(ouri)
+            )
         elif self.source != ex_source:
-            raise CooperationNotPossibleException("{0} differs incoming source {1}. Cooperation not possible for {2}"
-                                                  .format(self.source, ex_source, ouri))
+            raise CooperationNotPossibleException(
+                "{0} differs incoming source {1}. Cooperation not possible for {2}".format(
+                    self.source, ex_source, ouri
+                )
+            )
         elif not error is None:
-            raise OsakaException(
-                "Cooperation error for {0}: {1}".format(ouri, error))
+            raise OsakaException("Cooperation error for {0}: {1}".format(ouri, error))
 
     def isPrimary(self):
-        '''
+        """
         Is this the primary responsible for download
-        '''
+        """
         return self.primary
 
 
 class Spinner(object):
-    '''
+    """
     A class to spin on a download
     @author mstarch
-    '''
+    """
 
     def __init__(self, dlock, timeout, interval=0.5):
-        '''
+        """
         Initialize this spinner
         @param dlock: lock to spin on
-        '''
+        """
         self.dlock = dlock
         self.timeout = timeout
         self.interval = interval
 
     def spin(self):
-        '''
+        """
         Will spin on this lock until download completes or error is detected
-        '''
+        """
         tm = 0
         while True:
             error = self.dlock.getLockMetadata("error")

--- a/osaka/lock.py
+++ b/osaka/lock.py
@@ -5,11 +5,13 @@ from __future__ import absolute_import
 
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import json
 import socket
 import traceback
+
 # Py2k-3k imports
 try:
     import urllib.urlparse as urlparse
@@ -22,6 +24,7 @@ except:
 # Osaka imports
 import osaka.base
 import osaka.utils
+
 # Lock file metadata basics
 try:
     HOST_FQDN = socket.getfqdn()
@@ -32,43 +35,41 @@ try:
     PID = str(os.getpid())
 except:
     osaka.utils.LOGGER.warning("Failed to get PID, setting to 'unknown'")
-    PID = 'unknown'
+    PID = "unknown"
 INTERLOCK_NAME_TEMPLATE = "{0}.osaka.locked.json"
 
 WTF_CNT = 0
 
 
 class Lock(object):
-    '''
+    """
     A class to handle the lock file/URIs used by osaka. Simply hand it an
     Osaka URI to begin.
     @author mstarch
-    '''
+    """
 
     def __init__(self, ouri, handle=None, params={}):
-        '''
+        """
         Construct this lock object locking the give osaka-uri
         @param ouri: osaka uri for lock-handling
         @param handle: osaka handle for this lock file, if None specifiy params
         @param params: parameters for handle creation, if {} or None specify handle
-        '''
+        """
         self.ouri = ouri
         self.handle = handle
         self.params = params
         self.luri = Lock.getLockUri(self.ouri)
         self.secret = "Justin is an amazing person! Perhaps wax-sculpture worthy."
-        #self.lockExtras = {}
+        # self.lockExtras = {}
         self.locked = False
 
     def lock(self, lockMetadata={}):
-        '''
+        """
         Lock the object represented by this file
         @param lockMetadata: metadata to stick
-        '''
-        osaka.utils.LOGGER.debug(
-            "Locking {0} with {1}".format(self.ouri, self.luri))
-        tmp = {"pid": PID, "hostname": HOST_FQDN,
-               "osaka-lock-secret": self.secret}
+        """
+        osaka.utils.LOGGER.debug("Locking {0} with {1}".format(self.ouri, self.luri))
+        tmp = {"pid": PID, "hostname": HOST_FQDN, "osaka-lock-secret": self.secret}
         tmp.update(lockMetadata)
         # tmp.update(self.lockExtras)
         stream = io.StringIO(str(json.dumps(tmp)))
@@ -80,23 +81,23 @@ class Lock(object):
         self.locked = True
 
     def unlock(self):
-        '''
+        """
         Unlock the object represented by this object
-        '''
-        osaka.utils.LOGGER.debug(
-            "Unlocking {0} with {1}".format(self.ouri, self.luri))
+        """
+        osaka.utils.LOGGER.debug("Unlocking {0} with {1}".format(self.ouri, self.luri))
         with PermTemp(self.luri, self.handle, self.params) as handle:
             handle.rm(self.luri)
         self.locked = False
 
     def getLockMetadata(self, field):
-        '''
+        """
         Get a field out of the lock-uri metadata
         @param field: field to read from the lock-uri
         @return: lock-uri field
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Looking for {0} in lock-uri {1}".format(field, self.luri))
+            "Looking for {0} in lock-uri {1}".format(field, self.luri)
+        )
         with PermTemp(self.luri, self.handle, self.params) as handle:
             try:
                 filelike = handle.get(self.luri)
@@ -105,16 +106,17 @@ class Lock(object):
                 return None
 
     def setLockMetadata(self, field, value):
-        '''
+        """
         Get a field out of the lock-uri metadata
         @param field: field to read from the lock-uri
         @param value: value to set
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Looking for {0} in lock-uri {1}".format(field, self.luri))
-#        if not self.locked:
-#            self.lockExtras[field] = value
-#            return
+            "Looking for {0} in lock-uri {1}".format(field, self.luri)
+        )
+        #        if not self.locked:
+        #            self.lockExtras[field] = value
+        #            return
         with PermTemp(self.luri, self.handle, self.params) as handle:
             filelike = handle.get(self.luri)
             jsn = json.load(filelike)
@@ -123,11 +125,12 @@ class Lock(object):
             handle.put(stream, self.luri)
 
     def isLocked(self):
-        '''
+        """
         Check to see if the URI is locked
-        '''
+        """
         osaka.utils.LOGGER.info(
-            "Checking lock status of {0} in {1}".format(self.ouri, self.luri))
+            "Checking lock status of {0} in {1}".format(self.ouri, self.luri)
+        )
         if self.locked:
             return self.locked
         try:
@@ -138,32 +141,34 @@ class Lock(object):
 
     @staticmethod
     def getLockUri(ouri):
-        '''
+        """
         Gets the lockfile uri from the given ouri
         @param ouri: osaka-uri to wrap with the lock
-        '''
+        """
         parsed = urlparse.urlparse(ouri)
         parsed = parsed._replace(
-            path=INTERLOCK_NAME_TEMPLATE.format(parsed.path.rstrip("/")))
+            path=INTERLOCK_NAME_TEMPLATE.format(parsed.path.rstrip("/"))
+        )
         return parsed.geturl()
 
 
 class PermTemp(object):
-    '''
+    """
     A permanent or temporary wrapper for a handle. Allows the "with" clause to close if and only
     if we made a temporary handle
     @author mstarch
-    '''
+    """
 
     def __init__(self, luri, handle=None, params={}):
-        '''
+        """
         Initialize a new perm-temp object
-        '''
+        """
         self.luri = luri
         if handle is None:
             self.close = True
             osaka.utils.LOGGER.debug(
-                "Opening handler for lock-uri {0}".format(self.luri))
+                "Opening handler for lock-uri {0}".format(self.luri)
+            )
             self.handle = osaka.base.StorageBase.getStorageBackend(self.luri)
             self.handle.connect(self.luri, params)
             return
@@ -171,14 +176,14 @@ class PermTemp(object):
         self.close = False
 
     def __enter__(self):
-        '''
+        """
         Enter function 
-        '''
+        """
         return self.handle
 
     def __exit__(self, exception_type, exception_value, traceback):
-        '''
+        """
         Exit function
-        '''
+        """
         if self.close:
             self.handle.close()

--- a/osaka/lock.py
+++ b/osaka/lock.py
@@ -15,7 +15,7 @@ import traceback
 # Py2k-3k imports
 try:
     import urllib.urlparse as urlparse
-except ImportError as ime:
+except ImportError:
     import urllib.parse as urlparse
 try:
     import io as io
@@ -103,6 +103,11 @@ class Lock(object):
                 filelike = handle.get(self.luri)
                 return json.load(filelike).get(field, None)
             except Exception as e:
+                osaka.utils.LOGGER.warning(
+                    "Ignoring encountered exception: {}\n{}".format(
+                        e, traceback.format_exc()
+                    )
+                )
                 return None
 
     def setLockMetadata(self, field, value):
@@ -137,7 +142,6 @@ class Lock(object):
             return self.getLockMetadata("osaka-lock-secret") == self.secret
         except:
             return False
-        return ret
 
     @staticmethod
     def getLockUri(ouri):

--- a/osaka/main.py
+++ b/osaka/main.py
@@ -4,14 +4,25 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import range
 from future import standard_library
+
 standard_library.install_aliases()
 import osaka.base
 import osaka.utils
 import osaka.transfer
 
 
-def put(path, url, params={}, measure=False, output="./pge_metrics.json", lockMetadata={}, retries=0, ncoop=False, noclobber=False):
-    '''
+def put(
+    path,
+    url,
+    params={},
+    measure=False,
+    output="./pge_metrics.json",
+    lockMetadata={},
+    retries=0,
+    ncoop=False,
+    noclobber=False,
+):
+    """
     Put a file up to given url based on its scheme
     @param path: path to read file from (locally)
     @param url: url to put file at
@@ -20,15 +31,36 @@ def put(path, url, params={}, measure=False, output="./pge_metrics.json", lockMe
     @param output: (optional)output file to place metrics in
     @param lockMetadata: (optional)metadata to place in Osaka lock-out file
     @param retries: (optional)number of times to retry
-    '''
+    """
     osaka.utils.LOGGER.info(
-        "Running backwards-compatible 'Osaka Put' from {0} to {1}".format(path, url))
-    transfer(path, url, params, measure, output, lockMetadata,
-             retries=retries, ncoop=ncoop, noclobber=noclobber)
+        "Running backwards-compatible 'Osaka Put' from {0} to {1}".format(path, url)
+    )
+    transfer(
+        path,
+        url,
+        params,
+        measure,
+        output,
+        lockMetadata,
+        retries=retries,
+        ncoop=ncoop,
+        noclobber=noclobber,
+    )
 
 
-def get(url, path, params={}, measure=False, output="./pge_metrics.json", lockMetadata={}, retries=0, force=False, ncoop=False, noclobber=False):
-    '''
+def get(
+    url,
+    path,
+    params={},
+    measure=False,
+    output="./pge_metrics.json",
+    lockMetadata={},
+    retries=0,
+    force=False,
+    ncoop=False,
+    noclobber=False,
+):
+    """
     Get a URL to the given path based on scheme
     @param url: url to grab file from
     @param path: path to save file to (locally)
@@ -37,15 +69,37 @@ def get(url, path, params={}, measure=False, output="./pge_metrics.json", lockMe
     @param output: (optional)output file to place metrics in
     @param lockMetadata: (optional)metadata to place in Osaka lock-out file
     @param retries: (optional)number of times to retry
-    '''
+    """
     osaka.utils.LOGGER.info(
-        "Running backwards-compatible 'Osaka Get' from {0} to {1}".format(url, path))
-    transfer(url, path, params, measure, output, lockMetadata,
-             retries=retries, force=force, ncoop=ncoop, noclobber=noclobber)
+        "Running backwards-compatible 'Osaka Get' from {0} to {1}".format(url, path)
+    )
+    transfer(
+        url,
+        path,
+        params,
+        measure,
+        output,
+        lockMetadata,
+        retries=retries,
+        force=force,
+        ncoop=ncoop,
+        noclobber=noclobber,
+    )
 
 
-def transfer(source, dest, params={}, measure=False, output="./pge_metrics.json", lockMetadata={}, retries=0, force=False, ncoop=False, noclobber=False):
-    '''
+def transfer(
+    source,
+    dest,
+    params={},
+    measure=False,
+    output="./pge_metrics.json",
+    lockMetadata={},
+    retries=0,
+    force=False,
+    ncoop=False,
+    noclobber=False,
+):
+    """
     Transfer from one point to another
     @param source: source URI to transfer from
     @param dest: destination URI to transfer to
@@ -54,14 +108,27 @@ def transfer(source, dest, params={}, measure=False, output="./pge_metrics.json"
     @param output: (optional)output file to place metrics in
     @param lockMetadata: (optional)metadata to place in Osaka lock-out file
     @param retries: (optional)number of times to retry
-    '''
+    """
     osaka.utils.LOGGER.info(
-        "Running new-style 'Osaka Transfer' from {0} to {1}".format(source, dest))
+        "Running new-style 'Osaka Transfer' from {0} to {1}".format(source, dest)
+    )
     # if source.startswith("rsync://") or dest.startswith("rsync://"):
     #    rsync(source,dest,params,measure,output,lockMetadata)
     transfer = osaka.transfer.Transferer()
-    transfer.transfer(source, dest, params=params, measure=measure, metricsOutput=output,
-                      lockMetadata=lockMetadata, retries=retries, force=force, ncoop=ncoop, noclobber=noclobber)
+    transfer.transfer(
+        source,
+        dest,
+        params=params,
+        measure=measure,
+        metricsOutput=output,
+        lockMetadata=lockMetadata,
+        retries=retries,
+        force=force,
+        ncoop=ncoop,
+        noclobber=noclobber,
+    )
+
+
 # def rsync(source,dest,params={},measure=False,output="./pge_metrics.json",lockMetadata={}):
 #     '''
 #     Rsync from one backend to a valid rsync location
@@ -78,65 +145,67 @@ def transfer(source, dest, params={}, measure=False, output="./pge_metrics.json"
 
 
 def rmall(url, params={}, unlock=False, retries=0):
-    '''
+    """
     Remove a URL, recursively
     @param url: url to remove
     @param params: (optional)parameters to hand to backend, like passwords/usernames
     @param retries: (optional)number of times to retry
-    '''
+    """
     osaka.utils.LOGGER.info("Removing {0}".format(url))
     transfer = osaka.transfer.Transferer()
     transfer.remove(url, params, unlock=unlock, retries=retries)
 
 
 def isLocked(url, params={}):
-    '''
+    """
     Is the URL locked?
     @param url: url to remove
     @param params: (optional)parameters to hand to backend, like passwords/usernames
-    '''
+    """
     osaka.utils.LOGGER.info("Checking lock status of {0}".format(url))
     transfer = osaka.transfer.Transferer()
     return transfer.isLocked(url, params=params)
 
 
 def exists(url, params={}):
-    '''
+    """
     Checks the existence of a url
     @param url: url to check
     @param params: params to pass-in 
-    '''
+    """
     backend = osaka.base.StorageBase.getStorageBackend(url)
     backend.connect(url, params)
     return backend.exists(url)
 
 
 def size(url, params={}, retries=0, force=False):
-    '''
+    """
     Check the size of an object
-    '''
+    """
     uri = url.rstrip("/")
     osaka.utils.LOGGER.info("Sizing URI {0}".format(uri))
     handle = osaka.base.StorageBase.getStorageBackend(uri)
     lock = osaka.lock.Lock(uri, handle)
-    for retry in range(0, retries+1):
+    for retry in range(0, retries + 1):
         try:
             handle.connect(uri, params)
             if not force and lock.isLocked():
                 error = "URI {0} has not completed previous tranfer. Will not continue.".format(
-                    uri)
+                    uri
+                )
                 osaka.utils.LOGGER.error(error)
                 raise osaka.utils.OsakaException(error)
 
             def size_it(item):
-                ''' Size one item '''
-                osaka.utils.LOGGER.debug(
-                    "Sizing specific item {0}".format(item))
+                """ Size one item """
+                osaka.utils.LOGGER.debug("Sizing specific item {0}".format(item))
                 return handle.size(item)
+
             return sum(osaka.utils.product_composite_iterator(uri, handle, size_it))
         except Exception as e:
             osaka.utils.LOGGER.warning(
-                "Exception occurred, retrying({0}): {1}".format(retry+1, e))
+                "Exception occurred, retrying({0}): {1}".format(retry + 1, e)
+            )
         finally:
             handle.close()
     else:
@@ -148,29 +217,32 @@ def list(url, params={}, retries=0, force=False):
 
 
 def getChildren(url, params={}, retries=0, force=False):
-    '''
+    """
     Check the size of an object
-    '''
+    """
     uri = url.rstrip("/")
     osaka.utils.LOGGER.info("Get all children URI {0}".format(uri))
     handle = osaka.base.StorageBase.getStorageBackend(uri)
     lock = osaka.lock.Lock(uri, handle)
-    for retry in range(0, retries+1):
+    for retry in range(0, retries + 1):
         try:
             handle.connect(uri, params)
             if not force and lock.isLocked():
                 error = "URI {0} has not completed previous tranfer. Will not continue.".format(
-                    uri)
+                    uri
+                )
                 osaka.utils.LOGGER.error(error)
                 raise osaka.utils.OsakaException(error)
 
             def identity(item):
-                ''' Size one item '''
+                """ Size one item """
                 return item
+
             return osaka.utils.product_composite_iterator(uri, handle, identity)
         except Exception as e:
             osaka.utils.LOGGER.warning(
-                "Exception occurred, retrying({0}): {1}".format(retry+1, e))
+                "Exception occurred, retrying({0}): {1}".format(retry + 1, e)
+            )
         finally:
             handle.close()
     else:
@@ -178,10 +250,10 @@ def getChildren(url, params={}, retries=0, force=False):
 
 
 def supported(url):
-    '''
+    """
     Check to see if the url's scheme is supported
     @param url: url whose scheme to check
-    '''
+    """
     osaka.utils.LOGGER.info("Checking for backend supporting {0}".format(url))
     try:
         return not osaka.base.StorageBase.getStorageBackend(url) is None

--- a/osaka/storage/az.py
+++ b/osaka/storage/az.py
@@ -8,11 +8,9 @@ from future import standard_library
 
 standard_library.install_aliases()
 import re
-import azure.common
 import urllib.parse
 import datetime
 import os.path
-import json
 import osaka.base
 import osaka.utils
 import osaka.storage.file
@@ -53,20 +51,20 @@ class Azure(osaka.base.StorageBase):
         session_kwargs = {}
 
         # attempt to get account_name (as username) from url or parameters array
-        if not parsed.username is None:
+        if parsed.username is not None:
             session_kwargs["account_name"] = parsed.username
         elif "account_name" in params:
             session_kwargs["account_name"] = params["account_name"]
 
         # attempt to get account_key (as password) from url or parameters array
-        if not parsed.password is None:
+        if parsed.password is not None:
             session_kwargs["account_key"] = parsed.password
         elif "account_key" in params:
             session_kwargs["account_key"] = params["account_key"]
 
         # if neither account_name or account_key is populated, fallback to
         # directly parsing configuration file in ~/.azure
-        if not "account_name" in session_kwargs or not "account_key" in session_kwargs:
+        if "account_name" not in session_kwargs or "account_key" not in session_kwargs:
             # check if ~/.azure/config exists
             azure_config_path = os.environ["HOME"] + "/.azure/config"
             if os.path.isfile(azure_config_path):
@@ -146,7 +144,7 @@ class Azure(osaka.base.StorageBase):
             parsed.scheme
             + "://"
             + parsed.hostname
-            + (":" + str(parsed.port) if not parsed.port is None else "")
+            + (":" + str(parsed.port) if parsed.port is not None else "")
         )
         # Setup cache, and fill it with listings
         self.cache["__top__"] = uri

--- a/osaka/storage/example.py
+++ b/osaka/storage/example.py
@@ -1,11 +1,10 @@
-
-'''
+"""
 Example of a storage handler used with Osaka.
 parsed from the url:
     <scheme>://[<username>:<password>@]<hostname>:<port>/<path>
 
 @author starchmd
-'''
+"""
 from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
@@ -13,23 +12,26 @@ from __future__ import absolute_import
 
 
 from future import standard_library
+
 standard_library.install_aliases()
+
+
 class Example(object):
-    '''
+    """
     Example Osaka handler
-    '''
+    """
 
     def __init__(self, params={}):
-        '''
+        """
         Constructor:
             1. All parameters are in the params map
             2. Remember, this is called often 
                and called long before "connect"
-        '''
+        """
         print("Init the example handler")
 
     def connect(self, host, port, user, password, secure):
-        '''
+        """
         Connect to this storage medium.  All data is parsed out of the url and may be None
             scheme:
         @param host - may be None, host to connect to
@@ -40,46 +42,45 @@ class Example(object):
                       implementor must handle a None user
         @param password - may be None, password to connect with
                       implementor must handle a None password
-        '''
-        print("Connecting to example handler:",
-              host, port, user, password, secure)
+        """
+        print("Connecting to example handler:", host, port, user, password, secure)
 
     @classmethod
     def getSchemes(clazz):
-        '''
+        """
         Returns a list of schemes this handler handles
         Note: handling the scheme of another handler produces unknown results
         @returns list of handled schemes
-        '''
+        """
         return ["example", "examples"]
 
     def put(self, path, url):
-        '''
+        """
         Put the given path to the given url
         @param path - local path of file to put
         @param url - url to put file/folder to
-        '''
+        """
         print("Putting:", path, "to", url)
         return False
 
     def get(self, url, dest):
-        '''
+        """
         Get the url (file/folder) to local path
         @param url - url to get file/folder from
         @param path - path to place fetched files
-        '''
+        """
         print("Getting:", url, "to", dest)
         return False
 
     def close(self):
-        '''
+        """
         Close this connection
-        '''
+        """
         print("Closing backend")
 
     def rm(self, url):
-        '''
+        """
         Remove this file/folder
-        '''
+        """
         print("Removing product at:", url)
         return False

--- a/osaka/storage/file.py
+++ b/osaka/storage/file.py
@@ -19,147 +19,161 @@ import io
 import osaka.utils
 import osaka.base
 
-'''
+"""
 File handling using local moves and/or fabric 
 
 @author starchmd
-'''
+"""
 
 
 class File(osaka.base.StorageBase):
-    '''
+    """
     File handling for put/gets
-    '''
+    """
 
     def __init__(self):
-        '''
+        """
         Constructor
-        '''
+        """
         self.files = []
 
     def connect(self, uri, params={}):
-        '''
+        """
         Connects to the backend
-        '''
+        """
         osaka.utils.LOGGER.debug("Opening file handler")
 
     @staticmethod
     def getSchemes():
-        '''
+        """
         Returns a list of schemes this handler handles
         Note: handling the scheme of another handler produces unknown results
         @returns list of handled schemes
-        '''
+        """
         return ["", "file"]
 
     def get(self, uri):
-        '''
+        """
         Gets the URI (file) as a steam
         @param uri: uri to get
-        '''
+        """
         if uri.startswith("file:") and not uri.startswith("file:///"):
             raise Exception(
-                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris")
+                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris"
+            )
         osaka.utils.LOGGER.debug("Getting stream from URI: {0}".format(uri))
         fh = open(urllib.parse.urlparse(uri).path, "r")
         self.files.append(fh)
         return fh
 
     def put(self, stream, uri):
-        '''
+        """
         Puts a stream to a URI as a steam
         @param stream: stream to upload
         @param uri: uri to put
-        '''
+        """
         if uri.startswith("file:") and not uri.startswith("file:///"):
             raise Exception(
-                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris")
+                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris"
+            )
         osaka.utils.LOGGER.debug("Putting stream to URI: {0}".format(uri))
         path = urllib.parse.urlparse(uri).path
         try:
             os.makedirs(os.path.dirname(path))
         except Exception as e:
             osaka.utils.LOGGER.debug(
-                "Exception while creating directories {0}".format(e))
+                "Exception while creating directories {0}".format(e)
+            )
 
-        flags = 'wb' if isinstance(stream, io.BufferedIOBase) or isinstance(stream,
-                                                                            urllib3.response.HTTPResponse) else 'w'
+        flags = (
+            "wb"
+            if isinstance(stream, io.BufferedIOBase)
+            or isinstance(stream, urllib3.response.HTTPResponse)
+            else "w"
+        )
         with open(path, flags) as out:
             shutil.copyfileobj(stream, out)
         return osaka.utils.get_disk_usage(urllib.parse.urlparse(uri).path)
 
     def size(self, uri):
-        '''
+        """
         Size the URI (file) as a steam
         @param uri: uri to get
-        '''
+        """
         if uri.startswith("file:") and not uri.startswith("file:///"):
             raise Exception(
-                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris")
+                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris"
+            )
         osaka.utils.LOGGER.debug("Getting stream from URI: {0}".format(uri))
         return os.path.getsize(urllib.parse.urlparse(uri).path)
 
     def exists(self, uri):
-        '''
+        """
         Does the URI exist?
         @param uri: uri to check
-        '''
+        """
         if uri.startswith("file:") and not uri.startswith("file:///"):
             raise Exception(
-                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris")
+                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris"
+            )
         exts = os.path.exists(urllib.parse.urlparse(uri).path)
         osaka.utils.LOGGER.debug("Does URI {0} exist: {1}".format(uri, exts))
         return exts
 
     def list(self, uri):
-        '''
+        """
         List URI
         @param uri: uri to list
-        '''
+        """
         if uri.startswith("file:") and not uri.startswith("file:///"):
             raise Exception(
-                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris")
+                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris"
+            )
         tmp = urllib.parse.urlparse(uri).path
         if os.path.exists(tmp) and not os.path.isdir(tmp):
             return [tmp]
         return [os.path.join(uri, item) for item in os.listdir(tmp)]
 
     def isComposite(self, uri):
-        '''
+        """
         Detect if this uri is a composite uri (uri to collection of objects i.e. directory)
         @param uri: uri to list
-        '''
+        """
         if uri.startswith("file:") and not uri.startswith("file:///"):
             raise Exception(
-                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris")
+                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris"
+            )
         isDir = os.path.isdir(urllib.parse.urlparse(uri).path)
         osaka.utils.LOGGER.debug(
-            "Is URI {0} a directory: {1} {2}".format(uri, isDir, self.exists(uri)))
+            "Is URI {0} a directory: {1} {2}".format(uri, isDir, self.exists(uri))
+        )
         return isDir
 
     def isObjectStore(self):
         return False
 
     def close(self):
-        '''
+        """
         Close this backend
-        '''
+        """
         osaka.utils.LOGGER.debug("Closing file handler")
         for fh in self.files:
             try:
                 fh.close()
             except:
                 osaka.utils.LOGGER.debug(
-                    "Failed to close file-handle for: {0}".format(fh.name))
+                    "Failed to close file-handle for: {0}".format(fh.name)
+                )
 
     def rm(self, uri):
-        '''
+        """
         Remove this uri from backend
         @param uri: uri to remove
-        '''
+        """
         if uri.startswith("file:") and not uri.startswith("file:///"):
             raise Exception(
-                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris")
+                "Non-absolute paths and non-null hostnames not supported with 'file://' schemed uris"
+            )
         path = urllib.parse.urlparse(uri).path
         if os.path.isdir(path):
             shutil.rmtree(path)
@@ -168,38 +182,39 @@ class File(osaka.base.StorageBase):
 
 
 class FileHandlerConversion(object):
-    '''
+    """
     This class allows a user to create a file-based approach to handling streams for backends that
     cannot handle their streams independently.
-    '''
+    """
 
     def __init__(self, stream):
-        '''
+        """
         Initialize the class, accepting the stream and creating the temp file if needed
         @param stream: stream to process
-        '''
+        """
         self.filename = getattr(stream, "name", None)
         self.handler = None
         # If the stream is not a file, make a temporary file out of it
         if self.filename is None or not os.path.exists(self.filename):
             self.handler = File()
-            self.filename = "/tmp/osaka-temporary-" + \
-                            datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f")
+            self.filename = "/tmp/osaka-temporary-" + datetime.datetime.utcnow().strftime(
+                "%Y%m%d%H%M%S.%f"
+            )
             self.handler.connect(self.filename)
             self.handler.put(stream, self.filename)
 
     def __enter__(self):
-        '''
+        """
         Return the filename, whither real or temporary
-        '''
+        """
         return self.filename
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        '''
+        """
         Close the temporary file if it was created
         @param exc_type: unused
         @param exc_val: unused
         @param exc_tb: unused
-        '''
+        """
         if not self.handler is None:
             self.handler.rm(self.filename)

--- a/osaka/storage/file.py
+++ b/osaka/storage/file.py
@@ -216,5 +216,5 @@ class FileHandlerConversion(object):
         @param exc_val: unused
         @param exc_tb: unused
         """
-        if not self.handler is None:
+        if self.handler is not None:
             self.handler.rm(self.filename)

--- a/osaka/storage/ftp.py
+++ b/osaka/storage/ftp.py
@@ -11,11 +11,9 @@ from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
-import re
 import urllib.parse
 import datetime
 import os.path
-import json
 import osaka.base
 import osaka.utils
 import osaka.storage.file
@@ -84,7 +82,7 @@ class FTP(osaka.base.StorageBase):
         @param stream: stream to upload
         @param uri: uri to put
         """
-        raise OsakaException("Not implemented; implementation deferred")
+        raise NotImplementedError("Not implemented; implementation deferred")
 
     def exists(self, uri):
         """
@@ -153,4 +151,4 @@ class FTP(osaka.base.StorageBase):
         Remove this uri from backend
         @param uri: uri to remove
         """
-        raise OsakaException("Not implemented; implementation deferred")
+        raise NotImplementedError("Not implemented; implementation deferred")

--- a/osaka/storage/ftp.py
+++ b/osaka/storage/ftp.py
@@ -1,7 +1,7 @@
-'''
+"""
 An Osaka backend that connects to ftp
 @author mstarch
-'''
+"""
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 from builtins import open
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import re
 import urllib.parse
@@ -24,22 +25,22 @@ import ftplib
 
 
 class FTP(osaka.base.StorageBase):
-    '''
+    """
     An FTP connecion class used to connect to the FTP servers
-    '''
+    """
 
     def __init__(self):
-        '''
+        """
         Constructor
-        '''
+        """
         self.tmpfiles = []
 
     def connect(self, uri, params={}):
-        '''
+        """
         Connects to the backend, given the URI
         @param uri - ftp uri to connect to
         @param params - optional, parameters for the connection
-        '''
+        """
         parsed = urllib.parse.urlparse(uri)
         netloc = parsed.netloc
         username = parsed.username
@@ -48,108 +49,108 @@ class FTP(osaka.base.StorageBase):
         if username is None or password is None:
             rchandle = netrc.netrc()
             username, account, password = rchandle.authenticators(netloc)
-        osaka.utils.LOGGER.info(
-            "Logging into {0} with ({1})".format(netloc, username))
+        osaka.utils.LOGGER.info("Logging into {0} with ({1})".format(netloc, username))
         self.ftp = ftplib.FTP(netloc, username, password)
         # self.ftp.login()
         osaka.utils.LOGGER.debug("Successfully logged in")
 
     @staticmethod
     def getSchemes():
-        '''
+        """
         Returns a list of schemes this handler handles
         Note: handling the scheme of another handler produces unknown results
         @returns list of handled schemes
-        '''
+        """
         return ["ftp"]
 
     def get(self, uri):
-        '''
+        """
         Gets the URI ftp as a steam
         @param uri: uri to get
-        '''
+        """
         osaka.utils.LOGGER.debug("Getting stream from URI: {0}".format(uri))
         filename = urllib.parse.urlparse(uri).path
-        fname = "/tmp/osaka-ftp-"+str(datetime.datetime.now())
+        fname = "/tmp/osaka-ftp-" + str(datetime.datetime.now())
         with open(fname, "w") as tmpf:
-            self.ftp.retrbinary('RETR %s' % filename, tmpf.write)
+            self.ftp.retrbinary("RETR %s" % filename, tmpf.write)
         fh = open(fname, "r+b")
         self.tmpfiles.append(fh)
         fh.seek(0)
         return fh  # obj.get()["Body"]
 
     def put(self, stream, uri):
-        '''
+        """
         Puts a stream to a URI as a steam
         @param stream: stream to upload
         @param uri: uri to put
-        '''
+        """
         raise OsakaException("Not implemented; implementation deferred")
 
     def exists(self, uri):
-        '''
+        """
         Does the URI exist?
         @param uri: uri to check
-        '''
+        """
         osaka.utils.LOGGER.debug("Does URI {0} exist?".format(uri))
         # A key exists if it has some children
         return len(self.listAllChildren(uri)) > 0
 
     def list(self, uri):
-        '''
+        """
         List URI
         @param uri: uri to list
-        '''
+        """
         parsed = urllib.parse.urlparse(uri)
         filename = parsed.path
         listing = self.ftp.nlst(filename)
-        base = parsed.netloc if parsed.netloc.endswith(
-            "/") else parsed.netloc + "/"
-        listing = [parsed.scheme + "://" + base +
-                   item.lstrip("/") for item in listing]
+        base = parsed.netloc if parsed.netloc.endswith("/") else parsed.netloc + "/"
+        listing = [parsed.scheme + "://" + base + item.lstrip("/") for item in listing]
         return listing
 
     def isComposite(self, uri):
-        '''
+        """
         Detect if this uri is a composite uri (uri to collection of objects i.e. directory)
         @param uri: uri to list
-        '''
+        """
         osaka.utils.LOGGER.debug("Is URI {0} a directory".format(uri))
         children = self.list(uri)
         if len(children) == 0 or (len(children) == 1 and children[0] == uri):
             return False
         return True
 
-    def isObjectStore(self): return False
+    def isObjectStore(self):
+        return False
 
     def close(self):
-        '''
+        """
         Close this backend
-        '''
+        """
         osaka.utils.LOGGER.debug("Closing ftp handler")
         for fh in self.tmpfiles:
             try:
                 fh.close()
             except:
                 osaka.utils.LOGGER.debug(
-                    "Failed to close temporary file-handle for: {0}".format(fh.name))
+                    "Failed to close temporary file-handle for: {0}".format(fh.name)
+                )
             try:
                 os.remove(fh.name)
             except:
                 osaka.utils.LOGGER.debug(
-                    "Failed to remove temporary file-handle for: {0}".format(fh.name))
+                    "Failed to remove temporary file-handle for: {0}".format(fh.name)
+                )
 
     def size(self, uri):
-        '''
+        """
         Size this uri from backend
         @param uri: uri to size
-        '''
+        """
         filename = urllib.parse.urlparse(uri).path
         return self.size(filename)
 
     def rm(self, uri):
-        '''
+        """
         Remove this uri from backend
         @param uri: uri to remove
-        '''
+        """
         raise OsakaException("Not implemented; implementation deferred")

--- a/osaka/storage/gs.py
+++ b/osaka/storage/gs.py
@@ -8,10 +8,8 @@ from future import standard_library
 standard_library.install_aliases()
 import re
 from google.cloud import storage
-from google.cloud.exceptions import Conflict, Forbidden, NotFound
+from google.cloud.exceptions import NotFound
 import urllib.parse
-import datetime
-import os.path
 from io import StringIO
 
 import osaka.base
@@ -46,18 +44,18 @@ class GS(osaka.base.StorageBase):
         parsed = urllib.parse.urlparse(uri)
         session_kwargs = {}
         kwargs = {}
-        check_host = parsed.hostname if not "location" in params else params["location"]
-        if not parsed.hostname is None:
+        parsed.hostname if "location" not in params else params["location"]
+        if parsed.hostname is not None:
             kwargs["endpoint_url"] = "%s://%s" % (parsed.scheme, parsed.hostname)
         else:
             kwargs["endpoint_url"] = "%s://%s" % (parsed.scheme, kwargs["endpoint_url"])
-        if not parsed.port is None:
+        if parsed.port is not None:
             kwargs["endpoint_url"] = "%s:%s" % (kwargs["endpoint_url"], parsed.port)
-        if not parsed.username is None:
+        if parsed.username is not None:
             session_kwargs["gcp_access_key_id"] = parsed.username
         elif "gcp_access_key_id" in params:
             session_kwargs["gcp_access_key_id"] = params["gcp_access_key_id"]
-        if not parsed.password is None:
+        if parsed.password is not None:
             session_kwargs["gcp_secret_access_key"] = parsed.password
         elif "gcp_secret_access_key" in params:
             session_kwargs["gcp_secret_access_key"] = params["gcp_secret_access_key"]
@@ -133,7 +131,7 @@ class GS(osaka.base.StorageBase):
             parsed.scheme
             + "://"
             + parsed.hostname
-            + (":" + str(parsed.port) if not parsed.port is None else "")
+            + (":" + str(parsed.port) if parsed.port is not None else "")
         )
         return [
             uriBase + "/" + container + "/" + item.name
@@ -211,5 +209,5 @@ class GS(osaka.base.StorageBase):
         """
         try:
             return self.gs.get_bucket(bucket)
-        except NotFound as e:
+        except NotFound:
             return self.gs.create_bucket(bucket)

--- a/osaka/storage/http.py
+++ b/osaka/storage/http.py
@@ -32,8 +32,6 @@ This Osaka backend uses requests to handle HTTP requests.
 class HTTPStatusCode200Exception(Exception):
     """Exception class for 202 HTTP status code."""
 
-    pass
-
 
 class HTTP(osaka.base.StorageBase):
     """
@@ -47,16 +45,15 @@ class HTTP(osaka.base.StorageBase):
         """
         Constructor
         """
-        pass
 
     def connect(self, uri, params={}):
         """
         Connects to the backend
         """
-        self.timeout = 1800.0 if not "timeout" in params else params["timeout"]
+        self.timeout = 1800.0 if "timeout" not in params else params["timeout"]
         parsed = urllib.parse.urlparse(uri)
-        user = None if not "user" in parsed else parsed["user"]
-        password = None if not "password" in parsed else parsed["password"]
+        user = None if "user" not in parsed else parsed["user"]
+        password = None if "password" not in parsed else parsed["password"]
         osaka.utils.LOGGER.debug("Opening HTTP handler")
         if user is None or password is None:
             tmp = self.getNetRCCredentials(uri)
@@ -150,7 +147,7 @@ class HTTP(osaka.base.StorageBase):
             if ret.status_code != 200:
                 raise osaka.utils.OsakaException("Bad response for existence checking")
             return True
-        except Exception as e:
+        except Exception:
             pass
         osaka.utils.LOGGER.debug("HEAD call not allowed, attempting get w/o read")
         try:
@@ -228,7 +225,7 @@ class HTTP(osaka.base.StorageBase):
         Close this backend
         """
         osaka.utils.LOGGER.debug("Closing file handler")
-        if not self.session is None:
+        if self.session is not None:
             self.session.close()
 
     def rm(self, uri):
@@ -273,7 +270,7 @@ class HTTP(osaka.base.StorageBase):
         """
         # try:
         creds = clazz.getNetRCCredentials(uri)
-        if not user is None and not password is None:
+        if user is not None and password is not None:
             creds = {"user": user, "password": password}
         session = requests.Session()
         if creds is None:

--- a/osaka/storage/http.py
+++ b/osaka/storage/http.py
@@ -7,6 +7,7 @@ from builtins import int
 from builtins import next
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import re
@@ -19,36 +20,39 @@ import osaka.utils
 import osaka.base
 
 requests.packages.urllib3.disable_warnings()
-'''
+"""
 HTTP Handler
 
 This Osaka backend uses requests to handle HTTP requests. 
 
 @author starchmd
-'''
+"""
+
 
 class HTTPStatusCode200Exception(Exception):
     """Exception class for 202 HTTP status code."""
+
     pass
 
 
 class HTTP(osaka.base.StorageBase):
-    '''
+    """
     Http and WebDav handling backends
-    '''
+    """
+
     BLOCK_SIZE = 4096
     HREF_RE = re.compile(r'href\s*=\s*"([^"]+)"')
 
     def __init__(self):
-        '''
+        """
         Constructor
-        '''
+        """
         pass
 
     def connect(self, uri, params={}):
-        '''
+        """
         Connects to the backend
-        '''
+        """
         self.timeout = 1800.0 if not "timeout" in params else params["timeout"]
         parsed = urllib.parse.urlparse(uri)
         user = None if not "user" in parsed else parsed["user"]
@@ -60,129 +64,142 @@ class HTTP(osaka.base.StorageBase):
             password = None if tmp is None else tmp["password"]
         if "oauth" in params and not params["oauth"] is None:
             osaka.utils.LOGGER.info(
-                "Connecting to http using OAuth: {0}".format(params["oauth"]))
+                "Connecting to http using OAuth: {0}".format(params["oauth"])
+            )
             self.session = self.oauthSession(params["oauth"])
         else:
-            #connectionUri = parsed.scheme + "://" +parsed.hostname+(":"+str(parsed.port) if not parsed.port is None else "")
+            # connectionUri = parsed.scheme + "://" +parsed.hostname+(":"+str(parsed.port) if not parsed.port is None else "")
             osaka.utils.LOGGER.info(
-                "Connecting to http using with http: {0} with user: {1} and password {2}".format(uri, user, password))
-            self.session = self.standardSession(
-                uri, user, password, self.timeout)
+                "Connecting to http using with http: {0} with user: {1} and password {2}".format(
+                    uri, user, password
+                )
+            )
+            self.session = self.standardSession(uri, user, password, self.timeout)
 
     @staticmethod
     def getSchemes():
-        '''
+        """
         Returns a list of schemes this handler handles
         Note: handling the scheme of another handler produces unknown results
         @returns list of handled schemes
-        '''
+        """
         return ["http", "https"]
 
     def get(self, uri, text=False):
-        '''
+        """
         Gets the URI (file) as a steam
         @param uri: uri to get
         @param text: should we pull out text data instead of raw
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Getting stream from URI: {0} Timeout: {1}".format(uri, self.timeout))
+            "Getting stream from URI: {0} Timeout: {1}".format(uri, self.timeout)
+        )
         response = self.session.get(
-            uri, stream=True, verify=False, timeout=self.timeout)
+            uri, stream=True, verify=False, timeout=self.timeout
+        )
         osaka.utils.LOGGER.debug(
-            "Got HTTP status code: {}".format(response.status_code))
+            "Got HTTP status code: {}".format(response.status_code)
+        )
         response.raise_for_status()
 
         # catch 202 status code
         if response.status_code == 202:
-            raise HTTPStatusCode200Exception("Received 202 HTTP status code: {}".format(response.text))
-        
+            raise HTTPStatusCode200Exception(
+                "Received 202 HTTP status code: {}".format(response.text)
+            )
+
         if text:
             return response.text
         return response.raw
 
     def put(self, stream, uri):
-        '''
+        """
         Puts a stream to a URI as a steam
         @param stream: stream to upload
         @param uri: uri to put
-        '''
-        raise osaka.utils.OsakaException(
-            "Osaka HTTP does not support PUT requests")
+        """
+        raise osaka.utils.OsakaException("Osaka HTTP does not support PUT requests")
 
     def size(self, uri):
-        '''
+        """
         Get size try
         @param uri: uri to check
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Getting size of {0} exist? Timeout: {1}".format(uri, self.timeout))
+            "Getting size of {0} exist? Timeout: {1}".format(uri, self.timeout)
+        )
         response = self.session.get(
-            uri, stream=True, verify=False, timeout=self.timeout)
+            uri, stream=True, verify=False, timeout=self.timeout
+        )
         response.raise_for_status()
-        size = int(response.headers['content-length'])
+        size = int(response.headers["content-length"])
         response.close()
         return size
 
     def exists(self, uri):
-        '''
+        """
         Does the URI exist?
         @param uri: uri to check
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Does URI {0} exist? Timeout: {1}".format(uri, self.timeout))
+            "Does URI {0} exist? Timeout: {1}".format(uri, self.timeout)
+        )
         try:
             ret = self.session.head(uri, timeout=self.timeout)
             # Custom raise_for_status, to include any non-200 code forcing a different check
             if ret.status_code != 200:
-                raise osaka.utils.OsakaException(
-                    "Bad response for existence checking")
+                raise osaka.utils.OsakaException("Bad response for existence checking")
             return True
         except Exception as e:
             pass
-        osaka.utils.LOGGER.debug(
-            "HEAD call not allowed, attempting get w/o read")
+        osaka.utils.LOGGER.debug("HEAD call not allowed, attempting get w/o read")
         try:
             text = self.get(uri, text=True)
-            if re.search("\s*(?:<!DOCTYPE)|(?:<!doctype)", text):
-                raise osaka.utils.OsakaException(
-                    "Unauthorized, redirected to login")
-            osaka.utils.LOGGER.debug(
-                "Does URI {0} exist? {1}".format(uri, True))
+            if re.search(r"\s*(?:<!DOCTYPE)|(?:<!doctype)", text):
+                raise osaka.utils.OsakaException("Unauthorized, redirected to login")
+            osaka.utils.LOGGER.debug("Does URI {0} exist? {1}".format(uri, True))
             return True
         except Exception as e:
             if "404 Client Error:" in str(e):
-                osaka.utils.LOGGER.debug(
-                    "Does URI {0} exist? {1}".format(uri, False))
+                osaka.utils.LOGGER.debug("Does URI {0} exist? {1}".format(uri, False))
                 return False
             raise
 
     def list(self, uri):
-        '''
+        """
         List URI
         @param uri: uri to list
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Listing {0} composite. Timeout: {1}".format(uri, self.timeout))
+            "Listing {0} composite. Timeout: {1}".format(uri, self.timeout)
+        )
         response = self.session.get(
-            uri, stream=True, verify=False, timeout=self.timeout)
+            uri, stream=True, verify=False, timeout=self.timeout
+        )
         response.raise_for_status()
         chunks = response.iter_content(chunk_size=self.BLOCK_SIZE)
         try:
             first = next(chunks)
         except StopIteration:
             first = ""
-        if first.startswith("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""):
+        if first.startswith(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"'
+        ):
             for chunk in chunks:
                 first += chunk
             return [os.path.join(uri, child) for child in self.harvestChildren(first)]
 
     def isComposite(self, uri):
-        '''
+        """
         Detect if this uri is a composite uri (uri to collection of objects i.e. directory)
         @param uri: uri to list
-        '''
-        osaka.utils.LOGGER.debug("Is URI {0} composite? Timeout: {1}".format(uri, self.timeout))
-        response = self.session.get(uri, stream=True, verify=False, timeout=self.timeout)
+        """
+        osaka.utils.LOGGER.debug(
+            "Is URI {0} composite? Timeout: {1}".format(uri, self.timeout)
+        )
+        response = self.session.get(
+            uri, stream=True, verify=False, timeout=self.timeout
+        )
         response.raise_for_status()
         chunks = response.iter_content(chunk_size=self.BLOCK_SIZE)
         try:
@@ -190,10 +207,14 @@ class HTTP(osaka.base.StorageBase):
         except StopIteration:
             first = ""
         response.close()
-        if isinstance(first, str) and first.startswith("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""):
+        if isinstance(first, str) and first.startswith(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"'
+        ):
             osaka.utils.LOGGER.debug("Is URI {0} composite? {1}".format(uri, True))
             return True
-        elif isinstance(first, bytes) and first.startswith(b"<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\""):
+        elif isinstance(first, bytes) and first.startswith(
+            b'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"'
+        ):
             osaka.utils.LOGGER.debug("Is URI {0} composite? {1}".format(uri, True))
             return True
         osaka.utils.LOGGER.debug("Is URI {0} composite? {1}".format(uri, False))
@@ -203,27 +224,26 @@ class HTTP(osaka.base.StorageBase):
         return False
 
     def close(self):
-        '''
+        """
         Close this backend
-        '''
+        """
         osaka.utils.LOGGER.debug("Closing file handler")
         if not self.session is None:
             self.session.close()
 
     def rm(self, uri):
-        '''
+        """
         Remove this uri from backend
         @param uri: uri to remove
-        '''
-        raise osaka.utils.OsakaException(
-            "Osaka HTTP does not support 'rm' requests")
+        """
+        raise osaka.utils.OsakaException("Osaka HTTP does not support 'rm' requests")
 
     @classmethod
     def getNetRCCredentials(clazz, url):
-        '''
+        """
         Look up .netrc params 
         @param url - url to lookup .netrc parameters for
-        '''
+        """
         creds = requests.utils.get_netrc_auth(url)
         if creds is None:
             return None
@@ -244,13 +264,13 @@ class HTTP(osaka.base.StorageBase):
 
     @classmethod
     def standardSession(clazz, uri, user, password, timeout=1800.0):
-        '''
+        """
         Gets a standard requests session
         @param uri - uri to authentigate against
         @param user - username to use, may be None
         @param password - password to connect with, may be None
         @return: requests session
-        '''
+        """
         # try:
         creds = clazz.getNetRCCredentials(uri)
         if not user is None and not password is None:
@@ -269,32 +289,42 @@ class HTTP(osaka.base.StorageBase):
 
     @classmethod
     def oauthSession(clazz, oauth):
-        '''
+        """
         Returns an oauth session for use with this backend.
         @param oauth - oauth url to connect to
         @return: oauth session
-        '''
+        """
         try:
             creds = clazz.getNetRCCredentials(oauth)
             if creds is None:
                 raise osaka.utils.OsakaException(
-                    "Failed to get OAuth credentials from .netrc")
+                    "Failed to get OAuth credentials from .netrc"
+                )
             session = requests.Session()
             session.post(oauth, params=creds, verify=False).raise_for_status()
         except Exception as e:
             raise osaka.utils.OsakaException(
-                "Failed to get OAuth session from: {0}. {1}".format(oauth, e))
+                "Failed to get OAuth session from: {0}. {1}".format(oauth, e)
+            )
         return session
 
     @classmethod
     def harvestChildren(clazz, blob):
-        '''
+        """
         Harvests child links from the HTML that is returned from webdav
         @param blob - blob of text which is the HTML page
-        '''
+        """
         children = set()
         for match in clazz.HREF_RE.finditer(blob):
             child = match.group(1)
-            if not child.startswith("?") and not child.startswith("/") and not child.startswith("..") and not child.startswith("https://") and not child.startswith("#") and not child.startswith("'") and not child.startswith("http://"):
+            if (
+                not child.startswith("?")
+                and not child.startswith("/")
+                and not child.startswith("..")
+                and not child.startswith("https://")
+                and not child.startswith("#")
+                and not child.startswith("'")
+                and not child.startswith("http://")
+            ):
                 children.add(child)
         return children

--- a/osaka/storage/s3.py
+++ b/osaka/storage/s3.py
@@ -67,23 +67,23 @@ class S3(osaka.base.StorageBase):
         parsed = urllib.parse.urlparse(uri)
         session_kwargs = {}
         kwargs = {}
-        check_host = parsed.hostname if not "location" in params else params["location"]
+        check_host = parsed.hostname if "location" not in params else params["location"]
         for region, ep in get_region_info().items():
             if re.search(ep, check_host):
                 kwargs["endpoint_url"] = ep
                 session_kwargs["region_name"] = region
                 break
-        if not parsed.hostname is None:
+        if parsed.hostname is not None:
             kwargs["endpoint_url"] = "%s://%s" % (parsed.scheme, parsed.hostname)
         else:
             kwargs["endpoint_url"] = "%s://%s" % (parsed.scheme, kwargs["endpoint_url"])
-        if not parsed.port is None and parsed.port != 80 and parsed.port != 443:
+        if parsed.port is not None and parsed.port != 80 and parsed.port != 443:
             kwargs["endpoint_url"] = "%s:%s" % (kwargs["endpoint_url"], parsed.port)
-        if not parsed.username is None:
+        if parsed.username is not None:
             session_kwargs["aws_access_key_id"] = parsed.username
         elif "aws_access_key_id" in params:
             session_kwargs["aws_access_key_id"] = params["aws_access_key_id"]
-        if not parsed.password is None:
+        if parsed.password is not None:
             session_kwargs["aws_secret_access_key"] = parsed.password
         elif "aws_secret_access_key" in params:
             session_kwargs["aws_secret_access_key"] = params["aws_secret_access_key"]
@@ -161,7 +161,7 @@ class S3(osaka.base.StorageBase):
         bucket = self.bucket(container)
         obj = bucket.Object(key)
         extra = {}
-        if not self.encrypt is None:
+        if self.encrypt is not None:
             extra = {"ServerSideEncryption": self.encrypt}
         with osaka.storage.file.FileHandlerConversion(stream) as fn:
             obj.upload_file(fn, ExtraArgs=extra)
@@ -186,7 +186,7 @@ class S3(osaka.base.StorageBase):
             parsed.scheme
             + "://"
             + parsed.hostname
-            + (":" + str(parsed.port) if not parsed.port is None else "")
+            + (":" + str(parsed.port) if parsed.port is not None else "")
         )
         # Setup cache, and fill it with listings
         self.cache["__top__"] = uri

--- a/osaka/storage/sftp.py
+++ b/osaka/storage/sftp.py
@@ -78,7 +78,7 @@ class SFTP(object):
             print("As file")
             try:
                 self.sftp.mkdir(os.path.dirname(rpath))
-            except IOError as e:
+            except IOError:
                 pass
             dest = rpath
             try:
@@ -90,13 +90,13 @@ class SFTP(object):
         print("As Dir")
         try:
             self.sftp.mkdir(rpath)
-        except IOError as e:
+        except IOError:
             pass
         for dirpath, dirname, filenames in os.walk(path):
             extra = os.path.relpath(dirpath, os.path.dirname(path))
             try:
                 self.sftp.mkdir(os.path.join(rpath, extra))
-            except IOError as e:
+            except IOError:
                 pass
             for filename in filenames:
                 self.upload(

--- a/osaka/storage/sftp.py
+++ b/osaka/storage/sftp.py
@@ -6,32 +6,34 @@ from __future__ import absolute_import
 
 from builtins import int
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import os.path
 import stat
 import urllib.parse
 import paramiko
-'''
+
+"""
 A backend used to handle stfp using parimiko
 
 @author starchmd
-'''
+"""
 
 
 class SFTP(object):
-    '''
+    """
      SFTP handling for Osaka
-    '''
+    """
 
     def __init__(self, params={}):
-        '''
+        """
         Constructor
-        '''
+        """
         self.keyfile = params["keyfile"] if "keyfile" in params else None
 
     def connect(self, host=None, port=None, user=None, password=None, secure=False):
-        '''
+        """
         Connect to this storage medium.  All data is parsed out of the url and may be None
             scheme:
         @param host - may be None, host to connect to
@@ -42,28 +44,34 @@ class SFTP(object):
                       implementor must handle a None user
         @param password - may be None, password to connect with
                       implementor must handle a None password
-        '''
+        """
         self.client = paramiko.client.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.client.connect(host, port=22 if port is None else int(
-            port), username=user, password=password, key_filename=self.keyfile, timeout=15)
+        self.client.connect(
+            host,
+            port=22 if port is None else int(port),
+            username=user,
+            password=password,
+            key_filename=self.keyfile,
+            timeout=15,
+        )
         self.sftp = self.client.open_sftp()
 
     @classmethod
     def getSchemes(clazz):
-        '''
+        """
         Returns a list of schemes this handler handles
         Note: handling the scheme of another handler produces unknown results
         @returns list of handled schemes
-        '''
+        """
         return ["sftp"]
 
     def put(self, path, url):
-        '''
+        """
         Put the given path to the given url
         @param path - local path of file/folder to put
         @param url - url to put file/folder to
-        '''
+        """
         rpath = urllib.parse.urlparse(url).path.lstrip("/")
         print("\n\n\n\nUploading:", path)
         if not os.path.isdir(path):
@@ -91,37 +99,39 @@ class SFTP(object):
             except IOError as e:
                 pass
             for filename in filenames:
-                self.upload(os.path.join(dirpath, filename),
-                            os.path.join(rpath, extra, filename))
+                self.upload(
+                    os.path.join(dirpath, filename),
+                    os.path.join(rpath, extra, filename),
+                )
 
     def upload(self, path, rpath):
-        '''
+        """
         Uploads a file to remote path
         @param path - path to upload
         @param rpath - remote path to upload to
-        '''
+        """
         self.sftp.put(path, rpath)
         return True
 
     def get(self, url, path):
-        '''
+        """
         Get the url (file/folder) to local path
         @param url - url to get file/folder from
         @param path - path to place fetched files
-        '''
+        """
         rpath = urllib.parse.urlparse(url).path
         self.sftp.get(rpath, path)
 
     def rm(self, url):
-        '''
+        """
         Remove the item
         @param url - url to remove
-        '''
+        """
         rpath = urllib.parse.urlparse(url).path
         self.sftp.remove(rpath)
 
     def close(self):
-        '''
+        """
         Close this connection
-        '''
+        """
         self.client.close()

--- a/osaka/storage/webdav.py
+++ b/osaka/storage/webdav.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from builtins import int
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import re
@@ -22,7 +23,7 @@ import osaka.storage.file
 import osaka.storage.http
 
 requests.packages.urllib3.disable_warnings()
-'''
+"""
 WebDav Handler
 
 Osaka handler for the webdav backend services.  
@@ -31,60 +32,66 @@ Note: easywebdav is not used in all functions, as it assumes that the "PROPFIND"
 and on some workers, it is not. Thus, this backend uses the HTTP backend internally
 
 @author starchmd
-'''
+"""
 
 
 class DAV(osaka.base.StorageBase):
-    '''
+    """
     Http and WebDav handling backends
-    '''
+    """
 
     def __init__(self):
-        '''
+        """
         Constructor
-        '''
+        """
         pass
 
     def connect(self, uri, params={}):
-        '''
+        """
         Connects to the backend
-        '''
+        """
         osaka.utils.LOGGER.debug("Opening WebDav handler")
         # Grab information out of the URI
         username, password = osaka.utils.get_uri_username_and_password(uri)
         scheme, host = osaka.utils.get_uri_scheme_and_hostname(uri)
         # Setup webdav connection
-        self.webdav = easywebdav.connect(host, username=username, password=password, protocol=re.compile(
-            "^dav").sub("http", scheme), verify_ssl=False)
+        self.webdav = easywebdav.connect(
+            host,
+            username=username,
+            password=password,
+            protocol=re.compile("^dav").sub("http", scheme),
+            verify_ssl=False,
+        )
         self.httpHandler = osaka.storage.http.HTTP()
         self.httpHandler.connect(re.compile("^dav").sub("http", uri), params)
 
     @staticmethod
     def getSchemes():
-        '''
+        """
         Returns a list of schemes this handler handles
         Note: handling the scheme of another handler produces unknown results
         @returns list of handled schemes
-        '''
+        """
         return ["dav", "davs"]
 
     def get(self, uri, text=False):
-        '''
+        """
         Gets the URI (file) as a steam
         @param uri: uri to get
         @param text: should we pull out text data instead of raw
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Getting stream to URI: {0} Note: Using HTTP GET".format(uri))
+            "Getting stream to URI: {0} Note: Using HTTP GET".format(uri)
+        )
         # Use the standard HTTP handler for getting the product
         return self.httpHandler.get(re.compile("^dav").sub("http", uri), text=text)
 
     def put(self, stream, uri):
-        '''
+        """
         Puts a stream to a URI as a steam
         @param stream: stream to upload
         @param uri: uri to put
-        '''
+        """
         osaka.utils.LOGGER.debug("Putting stream to URI: {0}".format(uri))
         path = osaka.utils.get_uri_path(uri)
         # Attempt to create the directories needed
@@ -93,95 +100,106 @@ class DAV(osaka.base.StorageBase):
             self.webdav.delete(path)
         except Exception as e:
             osaka.utils.LOGGER.debug(
-                "Exception making directories and cleaning up existing product: {0}".format(e))
+                "Exception making directories and cleaning up existing product: {0}".format(
+                    e
+                )
+            )
         # Create a filename to handle this stream
         with osaka.storage.file.FileHandlerConversion(stream) as fn:
             # Handle zero-length separately from webdav
             if os.path.getsize(fn) == 0:
-                self.httpHandler.session.put(re.compile("^dav").sub(
-                    "http", uri), "", verify=False, timeout=self.httpHandler.timeout).raise_for_status()
+                self.httpHandler.session.put(
+                    re.compile("^dav").sub("http", uri),
+                    "",
+                    verify=False,
+                    timeout=self.httpHandler.timeout,
+                ).raise_for_status()
             else:
                 self.webdav.upload(fn, path)
         # Get size for put item
-        response = self.httpHandler.session.head(re.compile("^dav").sub(
-            "http", uri), verify=False, timeout=self.httpHandler.timeout)
+        response = self.httpHandler.session.head(
+            re.compile("^dav").sub("http", uri),
+            verify=False,
+            timeout=self.httpHandler.timeout,
+        )
         response.raise_for_status()
         return int(response.headers["Content-Length"])
 
     def size(self, uri):
-        '''
+        """
         Size of object
-        '''
+        """
         osaka.utils.LOGGER.debug(
-            "Size stream to URI: {0} Note: Using HTTP size".format(uri))
+            "Size stream to URI: {0} Note: Using HTTP size".format(uri)
+        )
         # Use the standard HTTP handler for getting the product
         return self.httpHandler.size(re.compile("^dav").sub("http", uri), text=text)
 
     def exists(self, uri):
-        '''
+        """
         Does the URI exist?
         @param uri: uri to check
-        '''
+        """
         osaka.utils.LOGGER.debug("Does URI {0} exist?".format(uri))
         try:
             path = osaka.utils.get_uri_path(uri)
             tmp = self.webdav.exists(path)
-            osaka.utils.LOGGER.debug(
-                "Does URI {0} exist? {1}".format(uri, tmp))
+            osaka.utils.LOGGER.debug("Does URI {0} exist? {1}".format(uri, tmp))
             return tmp
         except Exception as e:
             pass
         osaka.utils.LOGGER.debug("Failed to check existence using HEAD")
         try:
-            text = self.httpHandler.get(re.compile(
-                "^dav").sub("http", uri), text=True)
-            if re.search("\s*(?:<!DOCTYPE)|(?:<!doctype)", text):
-                raise osaka.utils.OsakaException(
-                    "Unauthorized, redirected to login")
-            osaka.utils.LOGGER.debug(
-                "Does URI {0} exist? {1}".format(uri, True))
+            text = self.httpHandler.get(re.compile("^dav").sub("http", uri), text=True)
+            if re.search(r"\s*(?:<!DOCTYPE)|(?:<!doctype)", text):
+                raise osaka.utils.OsakaException("Unauthorized, redirected to login")
+            osaka.utils.LOGGER.debug("Does URI {0} exist? {1}".format(uri, True))
             return True
         except Exception as e:
             if "404 Client Error:" in str(e):
-                osaka.utils.LOGGER.debug(
-                    "Does URI {0} exist? {1}".format(uri, False))
+                osaka.utils.LOGGER.debug("Does URI {0} exist? {1}".format(uri, False))
                 return False
             raise
 
     def list(self, uri):
-        '''
+        """
         List URI
         @param uri: uri to list
-        '''
+        """
         reg = re.compile("^http")
-        return [reg.sub("dav", uri) for uri in self.httpHandler.list(re.compile("^dav").sub("http", uri))]
+        return [
+            reg.sub("dav", uri)
+            for uri in self.httpHandler.list(re.compile("^dav").sub("http", uri))
+        ]
 
     def isComposite(self, uri):
-        '''
+        """
         Detect if this uri is a composite uri (uri to collection of objects i.e. directory)
         @param uri: uri to list
-        '''
+        """
         return self.httpHandler.isComposite(re.compile("^dav").sub("http", uri))
 
-    def isObjectStore(self): return False
+    def isObjectStore(self):
+        return False
 
     def close(self):
-        '''
+        """
         Close this backend
-        '''
+        """
         osaka.utils.LOGGER.debug("Closing DAV handler")
         self.httpHandler.close()
 
     def rm(self, uri):
-        '''
+        """
         Remove this uri from backend
         @param uri: uri to remove
-        '''
+        """
         path = osaka.utils.get_uri_path(uri)
         try:
             osaka.utils.LOGGER.debug("Removing {0} as a file".format(uri))
             self.webdav.delete(path)
         except Exception as e:
             osaka.utils.LOGGER.debug(
-                "Removing {0} as a directory, file encountered error {1}".format(uri, e))
+                "Removing {0} as a directory, file encountered error {1}".format(uri, e)
+            )
             self.webdav.rmdir(path)

--- a/osaka/storage/webdav.py
+++ b/osaka/storage/webdav.py
@@ -10,12 +10,9 @@ from future import standard_library
 standard_library.install_aliases()
 import os
 import re
-import urllib.parse
 import requests
 import easywebdav
-import datetime
 
-from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 
 import osaka.utils
 import osaka.base
@@ -44,7 +41,6 @@ class DAV(osaka.base.StorageBase):
         """
         Constructor
         """
-        pass
 
     def connect(self, uri, params={}):
         """
@@ -133,7 +129,7 @@ class DAV(osaka.base.StorageBase):
             "Size stream to URI: {0} Note: Using HTTP size".format(uri)
         )
         # Use the standard HTTP handler for getting the product
-        return self.httpHandler.size(re.compile("^dav").sub("http", uri), text=text)
+        return self.httpHandler.size(re.compile("^dav").sub("http", uri))
 
     def exists(self, uri):
         """
@@ -146,7 +142,7 @@ class DAV(osaka.base.StorageBase):
             tmp = self.webdav.exists(path)
             osaka.utils.LOGGER.debug("Does URI {0} exist? {1}".format(uri, tmp))
             return tmp
-        except Exception as e:
+        except Exception:
             pass
         osaka.utils.LOGGER.debug("Failed to check existence using HEAD")
         try:

--- a/osaka/tests/test_duck.py
+++ b/osaka/tests/test_duck.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 from future import standard_library
+
 standard_library.install_aliases()
 import unittest
 import inspect
@@ -10,28 +11,28 @@ import osaka.base
 
 
 class DuckTest(unittest.TestCase):
-    '''
+    """
     This class runs against all Osaka storage backends, making sure that they
     meet all the necessary requirements to be Osaka storage backends.
-    '''
+    """
 
     def test_ModuleDuckTypeing(self):
-        '''
+        """
         Tests the duck-typing of the Osaka storage modules
-        '''
+        """
         definitions = {
-            "__init__":   ["self"],
+            "__init__": ["self"],
             "getSchemes": [],
-            "connect":    ["self", "uri", "params"],
-            "get":        ["self", "uri"],
-            "put":        ["self", "stream", "uri"],
+            "connect": ["self", "uri", "params"],
+            "get": ["self", "uri"],
+            "put": ["self", "stream", "uri"],
             "listAllChildren": ["self", "uri"],
-            "exists":     ["self", "uri"],
-            "list":       ["self", "uri"],
+            "exists": ["self", "uri"],
+            "list": ["self", "uri"],
             "isComposite": ["self", "uri"],
-            "close":      ["self"],
-            "rm":         ["self", "uri"],
-            "size":       ["self", "uri"]
+            "close": ["self"],
+            "rm": ["self", "uri"],
+            "size": ["self", "uri"],
         }
         # Loop through the classes found by loading the backends and
         # ensure they are up-to-spec
@@ -42,11 +43,21 @@ class DuckTest(unittest.TestCase):
                     attr = getattr(clazz, func)
                 except AttributeError:
                     self.assertTrue(
-                        False, "{0} does not have function: {1}".format(clazz.__name__, func))
-                args, varargs, keywords, defaults, kwonlyargs, kwonlydefaults, annotations = inspect.getfullargspec(attr)
+                        False,
+                        "{0} does not have function: {1}".format(clazz.__name__, func),
+                    )
+                (
+                    args,
+                    varargs,
+                    keywords,
+                    defaults,
+                    kwonlyargs,
+                    kwonlydefaults,
+                    annotations,
+                ) = inspect.getfullargspec(attr)
                 # Remove defaulted arguments if possible
                 if not args is None and not defaults is None:
-                    count = len(args)-len(defaults)
+                    count = len(args) - len(defaults)
                     tmp = args[:count]
                     # Add back in any defined, but defaulted values
                     for arg in args[count:]:
@@ -54,5 +65,10 @@ class DuckTest(unittest.TestCase):
                             tmp.append(arg)
                     args = tmp
                 # Go through list of required arguments
-                self.assertEqual(args, values, "{0}.{1} has invalid arguments: {2} vs {3}".format(
-                    clazz.__name__, attr.__name__, values, args))
+                self.assertEqual(
+                    args,
+                    values,
+                    "{0}.{1} has invalid arguments: {2} vs {3}".format(
+                        clazz.__name__, attr.__name__, values, args
+                    ),
+                )

--- a/osaka/tests/test_duck.py
+++ b/osaka/tests/test_duck.py
@@ -43,7 +43,7 @@ class DuckTest(unittest.TestCase):
                 except AttributeError:
                     self.assertTrue(
                         False, "{0} does not have function: {1}".format(clazz.__name__, func))
-                args, varargs, keywords, defaults = inspect.getargspec(attr)
+                args, varargs, keywords, defaults, kwonlyargs, kwonlydefaults, annotations = inspect.getfullargspec(attr)
                 # Remove defaulted arguments if possible
                 if not args is None and not defaults is None:
                     count = len(args)-len(defaults)

--- a/osaka/tests/test_duck.py
+++ b/osaka/tests/test_duck.py
@@ -56,7 +56,7 @@ class DuckTest(unittest.TestCase):
                     annotations,
                 ) = inspect.getfullargspec(attr)
                 # Remove defaulted arguments if possible
-                if not args is None and not defaults is None:
+                if args is not None and defaults is not None:
                     count = len(args) - len(defaults)
                     tmp = args[:count]
                     # Add back in any defined, but defaulted values

--- a/osaka/tests/test_http.py
+++ b/osaka/tests/test_http.py
@@ -5,7 +5,6 @@ import osaka.storage.http
 
 
 class StorageHTTPTest(unittest.TestCase):
-
     def test_isComposite_with_binary_file(self):
         test_url = "http://landsat-pds.s3.amazonaws.com/scene_list.gz"
 
@@ -27,15 +26,19 @@ class StorageHTTPTest(unittest.TestCase):
         test_url = "https://httpstat.us/202"
         storage_http = osaka.storage.http.HTTP()
         storage_http.connect(test_url)
-        self.assertRaises(osaka.storage.http.HTTPStatusCode200Exception,
-                          storage_http.get, test_url)
+        self.assertRaises(
+            osaka.storage.http.HTTPStatusCode200Exception, storage_http.get, test_url
+        )
         storage_http.close()
 
     def test_404_http_status(self):
         test_url = "https://httpstat.us/404"
         storage_http = osaka.storage.http.HTTP()
         storage_http.connect(test_url)
-        self.assertRaisesRegex(requests.exceptions.HTTPError, 
-                               "404 Client Error.+$",
-                               storage_http.get, test_url)
+        self.assertRaisesRegex(
+            requests.exceptions.HTTPError,
+            "404 Client Error.+$",
+            storage_http.get,
+            test_url,
+        )
         storage_http.close()

--- a/osaka/tests/test_lockfile.py
+++ b/osaka/tests/test_lockfile.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from builtins import open
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import json
@@ -16,16 +17,17 @@ import requests.exceptions
 
 import osaka.main
 import osaka.tests.util
-'''
+
+"""
 Created on July 27, 2017
 
 @author: mstarch
-'''
+"""
 
 
 # TODO: fix unit tests for circleci
 
-#class LockfileTest(unittest.TestCase):
+# class LockfileTest(unittest.TestCase):
 #    '''
 #    A test that attempts to ensure that the lockfiles are being created and
 #    with the correct standards. That is:

--- a/osaka/tests/test_lockfile.py
+++ b/osaka/tests/test_lockfile.py
@@ -2,21 +2,10 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import open
-from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
-import os
-import json
-import copy
-import time
-import subprocess
-import unittest
-import requests.exceptions
 
-import osaka.main
-import osaka.tests.util
 
 """
 Created on July 27, 2017

--- a/osaka/tests/test_noclobber.py
+++ b/osaka/tests/test_noclobber.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import copy
@@ -15,16 +16,17 @@ import requests.exceptions
 
 import osaka.main
 import osaka.tests.util
-'''
+
+"""
 Created on Aug, 2017
 
 @author: mstarch
-'''
+"""
 
 
 # TODO: fix unit tests for circleci
 
-#class NoClobberTest(unittest.TestCase):
+# class NoClobberTest(unittest.TestCase):
 #    '''
 #    A test that tries the rmall function.
 #    '''

--- a/osaka/tests/test_noclobber.py
+++ b/osaka/tests/test_noclobber.py
@@ -2,20 +2,10 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
-import os
-import copy
-import time
-import math
-import subprocess
-import unittest
-import requests.exceptions
 
-import osaka.main
-import osaka.tests.util
 
 """
 Created on Aug, 2017

--- a/osaka/tests/test_retry.py
+++ b/osaka/tests/test_retry.py
@@ -2,20 +2,10 @@ from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
-import os
-import copy
-import time
-import math
-import subprocess
-import unittest
-import requests.exceptions
 
-import osaka.main
-import osaka.tests.util
 
 """
 Created on Oct 31, 2016

--- a/osaka/tests/test_retry.py
+++ b/osaka/tests/test_retry.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import copy
@@ -15,16 +16,17 @@ import requests.exceptions
 
 import osaka.main
 import osaka.tests.util
-'''
+
+"""
 Created on Oct 31, 2016
 
 @author: mstarch
-'''
+"""
 
 
 # TODO: fix unit tests for circleci
 
-#class RetryTest(unittest.TestCase):
+# class RetryTest(unittest.TestCase):
 #    '''
 #    A test that tries the rmall function.
 #    '''

--- a/osaka/tests/test_s3.py
+++ b/osaka/tests/test_s3.py
@@ -1,7 +1,6 @@
 import io
 import unittest
 from mock import patch
-import requests.exceptions
 from moto import mock_s3
 import botocore
 from botocore.exceptions import ClientError

--- a/osaka/tests/test_s3.py
+++ b/osaka/tests/test_s3.py
@@ -19,8 +19,8 @@ mock_counter_threshold = 3
 def mock_make_api_call(self, operation_name, kwarg):
     """Mock the HeadObject operation to raise a 404."""
 
-    if operation_name == 'HeadObject':
-        parsed_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
+    if operation_name == "HeadObject":
+        parsed_response = {"Error": {"Code": "404", "Message": "Not Found"}}
         raise ClientError(parsed_response, operation_name)
     return orig(self, operation_name, kwarg)
 
@@ -30,54 +30,66 @@ def counted_mock_make_api_call(self, operation_name, kwarg):
 
     global mock_counter
     mock_counter += 1
-    if operation_name == 'HeadObject' and mock_counter < mock_counter_threshold:
-        parsed_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
+    if operation_name == "HeadObject" and mock_counter < mock_counter_threshold:
+        parsed_response = {"Error": {"Code": "404", "Message": "Not Found"}}
         raise ClientError(parsed_response, operation_name)
     return orig(self, operation_name, kwarg)
 
 
 class StorageS3Test(unittest.TestCase):
-
     @mock_s3
     def setUp(self):
         """Setup."""
 
         self.test_url = "s3://s3.us-west-2.amazonaws.com/landsat-pds/scene_list.gz"
-        self.s3 = boto3.client('s3', region_name='us-west-2')
+        self.s3 = boto3.client("s3", region_name="us-west-2")
 
     @mock_s3
     def test_s3_get(self):
         """Test get from S3."""
 
-        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
-        self.s3.put_object(Bucket='landsat-pds', Key='scene_list.gz', Body='test_s3_get')
+        self.s3.create_bucket(
+            Bucket="landsat-pds",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+        self.s3.put_object(
+            Bucket="landsat-pds", Key="scene_list.gz", Body="test_s3_get"
+        )
         storage_s3 = osaka.storage.s3.S3()
         storage_s3.connect(self.test_url)
         fh = storage_s3.get(self.test_url)
-        assert fh.read().decode() == 'test_s3_get'
+        assert fh.read().decode() == "test_s3_get"
         storage_s3.close()
 
     @mock_s3
     def test_s3_put(self):
         """Test put to S3."""
 
-        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
+        self.s3.create_bucket(
+            Bucket="landsat-pds",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
         storage_s3 = osaka.storage.s3.S3()
         storage_s3.connect(self.test_url)
         f = io.StringIO("test_s3_put")
         storage_s3.put(f, self.test_url)
         storage_s3.close()
-        obj = self.s3.get_object(Bucket='landsat-pds', Key='scene_list.gz')
-        assert obj['Body'].read().decode() == 'test_s3_put'
+        obj = self.s3.get_object(Bucket="landsat-pds", Key="scene_list.gz")
+        assert obj["Body"].read().decode() == "test_s3_put"
 
     @mock_s3
     def test_s3_eventual_consistency_error(self):
         """Test exponential backoff works to retry object
            metadata reload for some time and eventually bubbles up the exception."""
 
-        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
+        self.s3.create_bucket(
+            Bucket="landsat-pds",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
         with self.assertRaises(ClientError):
-            with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
+            with patch(
+                "botocore.client.BaseClient._make_api_call", new=mock_make_api_call
+            ):
                 storage_s3 = osaka.storage.s3.S3()
                 storage_s3.connect(self.test_url)
                 f = io.StringIO("test_s3_eventual_consistency_error")
@@ -88,12 +100,19 @@ class StorageS3Test(unittest.TestCase):
         """Test exponential backoff works to retry object metadata reload for some time and 
            eventually succeeds."""
 
-        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
-        with patch('botocore.client.BaseClient._make_api_call', new=counted_mock_make_api_call):
+        self.s3.create_bucket(
+            Bucket="landsat-pds",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+        with patch(
+            "botocore.client.BaseClient._make_api_call", new=counted_mock_make_api_call
+        ):
             storage_s3 = osaka.storage.s3.S3()
             storage_s3.connect(self.test_url)
             f = io.StringIO("test_s3_eventual_consistency_handling")
             storage_s3.put(f, self.test_url)
             storage_s3.close()
-            obj = self.s3.get_object(Bucket='landsat-pds', Key='scene_list.gz')
-            assert obj['Body'].read().decode() == 'test_s3_eventual_consistency_handling'
+            obj = self.s3.get_object(Bucket="landsat-pds", Key="scene_list.gz")
+            assert (
+                obj["Body"].read().decode() == "test_s3_eventual_consistency_handling"
+            )

--- a/osaka/tests/test_s3.py
+++ b/osaka/tests/test_s3.py
@@ -1,0 +1,99 @@
+import io
+import unittest
+from mock import patch
+import requests.exceptions
+from moto import mock_s3
+import botocore
+from botocore.exceptions import ClientError
+import boto3
+
+import osaka.storage.s3
+
+
+orig = botocore.client.BaseClient._make_api_call
+
+mock_counter = 0
+mock_counter_threshold = 3
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    """Mock the HeadObject operation to raise a 404."""
+
+    if operation_name == 'HeadObject':
+        parsed_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
+        raise ClientError(parsed_response, operation_name)
+    return orig(self, operation_name, kwarg)
+
+
+def counted_mock_make_api_call(self, operation_name, kwarg):
+    """Mock the HeadObject operation to raise a 404 until a counter is reached."""
+
+    global mock_counter
+    mock_counter += 1
+    if operation_name == 'HeadObject' and mock_counter < mock_counter_threshold:
+        parsed_response = {'Error': {'Code': '404', 'Message': 'Not Found'}}
+        raise ClientError(parsed_response, operation_name)
+    return orig(self, operation_name, kwarg)
+
+
+class StorageS3Test(unittest.TestCase):
+
+    @mock_s3
+    def setUp(self):
+        """Setup."""
+
+        self.test_url = "s3://s3.us-west-2.amazonaws.com/landsat-pds/scene_list.gz"
+        self.s3 = boto3.client('s3', region_name='us-west-2')
+
+    @mock_s3
+    def test_s3_get(self):
+        """Test get from S3."""
+
+        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
+        self.s3.put_object(Bucket='landsat-pds', Key='scene_list.gz', Body='test_s3_get')
+        storage_s3 = osaka.storage.s3.S3()
+        storage_s3.connect(self.test_url)
+        fh = storage_s3.get(self.test_url)
+        assert fh.read().decode() == 'test_s3_get'
+        storage_s3.close()
+
+    @mock_s3
+    def test_s3_put(self):
+        """Test put to S3."""
+
+        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
+        storage_s3 = osaka.storage.s3.S3()
+        storage_s3.connect(self.test_url)
+        f = io.StringIO("test_s3_put")
+        storage_s3.put(f, self.test_url)
+        storage_s3.close()
+        obj = self.s3.get_object(Bucket='landsat-pds', Key='scene_list.gz')
+        assert obj['Body'].read().decode() == 'test_s3_put'
+
+    @mock_s3
+    def test_s3_eventual_consistency_error(self):
+        """Test exponential backoff works to retry object
+           metadata reload for some time and eventually bubbles up the exception."""
+
+        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
+        with self.assertRaises(ClientError):
+            with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call):
+                storage_s3 = osaka.storage.s3.S3()
+                storage_s3.connect(self.test_url)
+                f = io.StringIO("test_s3_eventual_consistency_error")
+                storage_s3.put(f, self.test_url)
+
+    @mock_s3
+    def test_s3_eventual_consistency_handling(self):
+        """Test exponential backoff works to retry object metadata reload for some time and 
+           eventually succeeds."""
+
+        self.s3.create_bucket(Bucket='landsat-pds', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
+        with patch('botocore.client.BaseClient._make_api_call', new=counted_mock_make_api_call):
+            storage_s3 = osaka.storage.s3.S3()
+            storage_s3.connect(self.test_url)
+            f = io.StringIO("test_s3_eventual_consistency_handling")
+            storage_s3.put(f, self.test_url)
+            storage_s3.close()
+            obj = self.s3.get_object(Bucket='landsat-pds', Key='scene_list.gz')
+            assert obj['Body'].read().decode() == 'test_s3_eventual_consistency_handling'

--- a/osaka/tests/test_timeout.py
+++ b/osaka/tests/test_timeout.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import copy
@@ -13,16 +14,17 @@ import requests.exceptions
 
 import osaka.main
 import osaka.tests.util
-'''
+
+"""
 Created on Oct 31, 2016
 
 @author: mstarch
-'''
+"""
 
 
 # TODO: fix unit tests for circleci
 
-#class TimeoutTest(unittest.TestCase):
+# class TimeoutTest(unittest.TestCase):
 #    '''
 #    A test that setus up high and low timeouts to ensure that the timeouts
 #    work properly.

--- a/osaka/tests/test_timeout.py
+++ b/osaka/tests/test_timeout.py
@@ -2,18 +2,10 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import str
 from future import standard_library
 
 standard_library.install_aliases()
-import os
-import copy
-import subprocess
-import unittest
-import requests.exceptions
 
-import osaka.main
-import osaka.tests.util
 
 """
 Created on Oct 31, 2016

--- a/osaka/tests/test_transfer.py
+++ b/osaka/tests/test_transfer.py
@@ -3,15 +3,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from builtins import str
 
 from future import standard_library
 
 standard_library.install_aliases()
-import re
 import os
-import copy
-import subprocess
 import unittest
 
 import osaka.main

--- a/osaka/tests/test_transfer.py
+++ b/osaka/tests/test_transfer.py
@@ -21,29 +21,38 @@ import osaka.tests.util
 import requests
 
 requests.packages.urllib3.disable_warnings()
-'''
+"""
 Created on Aug 29, 2016
 
 @author: mstarch
-'''
+"""
 
 
 class SimpleTransferTest(unittest.TestCase):
-
     def test_http_download_to_file(self):
         source_uri = "http://landsat-pds.s3.amazonaws.com/scene_list.gz"
         dest_uri = "scene_list.gz"
 
         try:
-            osaka.main.transfer(source_uri, dest_uri, params={}, measure=False, output="./pge_metrics.json",
-                                lockMetadata={}, retries=0, force=False, ncoop=False, noclobber=False)
+            osaka.main.transfer(
+                source_uri,
+                dest_uri,
+                params={},
+                measure=False,
+                output="./pge_metrics.json",
+                lockMetadata={},
+                retries=0,
+                force=False,
+                ncoop=False,
+                noclobber=False,
+            )
         finally:
             os.remove(dest_uri)
 
 
 # TODO: fix unit tests for circleci
 
-#class TransferTest(unittest.TestCase):
+# class TransferTest(unittest.TestCase):
 #    '''
 #    A test that flushes out standard transfer functions between all backends.
 #    Performs the cross-product between the inputs and the outputs.

--- a/osaka/tests/util.py
+++ b/osaka/tests/util.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import absolute_import
 from builtins import open
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import json
@@ -17,21 +18,23 @@ try:
     from subprocess import DEVNULL  # py3k
 except ImportError:
     import os
-    DEVNULL = open(os.devnull, 'wb')
+
+    DEVNULL = open(os.devnull, "wb")
 
 
 def load_test_config():
-    '''
+    """
     Load a test configuration
-    '''
+    """
     with open(os.path.join(os.path.dirname(__file__), "test.json")) as fp:
         return json.load(fp)
 
 
 def scpWorkerObject(self, obj):
-    '''
-    '''
+    """
+    """
     ret = subprocess.call(
-        ["scp", "-r", obj, self.worker+":/data/work/"], stdout=DEVNULL, stderr=DEVNULL)
+        ["scp", "-r", obj, self.worker + ":/data/work/"], stdout=DEVNULL, stderr=DEVNULL
+    )
     if ret != 0:
         raise Exception("Failed to SCP input to WebDav worker")

--- a/osaka/tests/util.py
+++ b/osaka/tests/util.py
@@ -17,8 +17,6 @@ logging.basicConfig(level=logging.ERROR)
 try:
     from subprocess import DEVNULL  # py3k
 except ImportError:
-    import os
-
     DEVNULL = open(os.devnull, "wb")
 
 

--- a/osaka/transfer.py
+++ b/osaka/transfer.py
@@ -1,8 +1,8 @@
-'''
+"""
 Created on Apr 27, 2016
 
 @author: mstarch
-'''
+"""
 from __future__ import division
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -11,6 +11,7 @@ from builtins import range
 from builtins import open
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import os
 import traceback
@@ -26,12 +27,24 @@ import osaka.utils
 
 
 class Transferer(object):
-    '''
+    """
     A class used to atomically transfer files between Osaka storage endpoints
-    '''
+    """
 
-    def transfer(self, source, dest, params={}, measure=False, metricsOutput="./pge_metrics.json", lockMetadata={}, retries=0, force=False, ncoop=False, noclobber=False):
-        '''
+    def transfer(
+        self,
+        source,
+        dest,
+        params={},
+        measure=False,
+        metricsOutput="./pge_metrics.json",
+        lockMetadata={},
+        retries=0,
+        force=False,
+        ncoop=False,
+        noclobber=False,
+    ):
+        """
         Transfer an objects between source and dest
         @param source: source osaka-style URI
         @param dest: destination osaka-style URI
@@ -40,18 +53,19 @@ class Transferer(object):
         @param force: force a fetch of failed transfers
         @param ncoop: fail rather than cooperate with an already running osaka
         @param noclobber: raise exception if you will clobber an existing object
-        '''
+        """
         metrics = None
         # Refine uris to be standard
         source = source.rstrip("/")
         dest = dest.rstrip("/")
         osaka.utils.LOGGER.info(
-            "Opening connections for {0} and {1}".format(source, dest))
+            "Opening connections for {0} and {1}".format(source, dest)
+        )
         # Get handlers for the source and destination
         shandle = osaka.base.StorageBase.getStorageBackend(source)
         dhandle = osaka.base.StorageBase.getStorageBackend(dest)
         err = RuntimeError("Max retries reached but true exception not preserved.")
-        for retry in range(0, retries+1):
+        for retry in range(0, retries + 1):
             try:
                 shandle.connect(source, params)
                 dhandle.connect(dest, params)
@@ -62,40 +76,49 @@ class Transferer(object):
                 dlock = osaka.lock.Lock(dest, dhandle)
                 if source == dest:
                     error = "Source, {0}, and destination, {1}, are the same".format(
-                        source, dest)
+                        source, dest
+                    )
                     osaka.utils.LOGGER.error(error)
                     raise osaka.utils.OsakaException(error)
                 elif dhandle.exists(dest) and noclobber:
                     error = "Destination, {0}, already exists and no-clobber is set".format(
-                        dest)
+                        dest
+                    )
                     osaka.utils.LOGGER.error(error)
                     raise osaka.utils.NoClobberException(error)
                 if slock.isLocked() and not force:
                     error = "Source {0} has not completed previous tranfer. Will not continue.".format(
-                        source)
+                        source
+                    )
                     osaka.utils.LOGGER.error(error)
                     raise osaka.utils.OsakaException(error)
                 elif slock.isLocked() and force:
                     error = "Source {0} has not completed previous tranfer. Will continue by force.".format(
-                        source)
+                        source
+                    )
                     osaka.utils.LOGGER.warning(error)
                 osaka.utils.LOGGER.info(
-                    "Transferring between {0} and {1}".format(source, dest))
+                    "Transferring between {0} and {1}".format(source, dest)
+                )
                 # Atomically upload the file or files
                 with osaka.cooperator.Cooperator(source, dlock, lockMetadata) as coop:
                     if coop.isPrimary():
-                        metrics = self.transfer_uri(
-                            source, shandle, dest, dhandle)
+                        metrics = self.transfer_uri(source, shandle, dest, dhandle)
                     elif ncoop:
                         raise osaka.utils.CooperationRefusedException(
-                            "Competeing Osaka instance running, and cooperation was turned off")
+                            "Competeing Osaka instance running, and cooperation was turned off"
+                        )
                     else:
                         osaka.cooperator.Spinner(
-                            dlock, params.get("timeout", -1)).spin()
+                            dlock, params.get("timeout", -1)
+                        ).spin()
                 break
             except Exception as e:
                 osaka.utils.LOGGER.warning(
-                    "Exception occurred, retrying({0}): {1}\n{2}".format(retry+1, e, traceback.format_exc()))
+                    "Exception occurred, retrying({0}): {1}\n{2}".format(
+                        retry + 1, e, traceback.format_exc()
+                    )
+                )
                 err = e
             finally:
                 shandle.close()
@@ -107,99 +130,104 @@ class Transferer(object):
             self.writeMetrics(metrics, metricsOutput)
 
     def transfer_uri(self, source, shandle, dest, dhandle):
-        '''
+        """
         Transfer a URI recursing into it if it is a composite
-        '''
+        """
         metrics = {
             "source": source,
             "destination": dest,
             "type": "osaka-transfer",
-            "time_start": datetime.datetime.utcnow()
+            "time_start": datetime.datetime.utcnow(),
         }
 
         def transfer_one(uri):
-            ''' Transfer a single item '''
+            """ Transfer a single item """
             relative = os.path.relpath(uri, source)
-            specificDest = dest if relative == "." else os.path.join(
-                dest, relative)
+            specificDest = dest if relative == "." else os.path.join(dest, relative)
             osaka.utils.LOGGER.debug(
-                "Transferring individual object from {0} to {1}".format(uri, specificDest))
+                "Transferring individual object from {0} to {1}".format(
+                    uri, specificDest
+                )
+            )
             stream = shandle.get(uri)
             count = dhandle.put(stream, specificDest)
             stream.close()
             return count
-        counts = osaka.utils.product_composite_iterator(
-            source, shandle, transfer_one)
+
+        counts = osaka.utils.product_composite_iterator(source, shandle, transfer_one)
         metrics["time_end"] = datetime.datetime.utcnow()
         metrics["size"] = sum(counts)
         return metrics
 
     def remove(self, uri, params={}, unlock=False, retries=0):
-        '''
+        """
         Removal URI and all children
         @param uri: URI to remove
         @param unlock: shall we unlock first? Otherwise error on locked file
-        '''
+        """
         uri = uri.rstrip("/")
         osaka.utils.LOGGER.info("Removing URI {0}".format(uri))
         handle = osaka.base.StorageBase.getStorageBackend(uri)
         lock = osaka.lock.Lock(uri, handle)
-        for retry in range(0, retries+1):
+        for retry in range(0, retries + 1):
             try:
                 handle.connect(uri, params)
                 if not unlock and lock.isLocked():
                     error = "URI {0} has not completed previous tranfer. Will not continue.".format(
-                        uri)
+                        uri
+                    )
                     osaka.utils.LOGGER.error(error)
                     raise osaka.utils.OsakaException(error)
                 elif lock.isLocked():
                     lock.unlock()
 
                 def remove_one(item):
-                    ''' Remove one item '''
-                    osaka.utils.LOGGER.debug(
-                        "Removing specific item {0}".format(item))
+                    """ Remove one item """
+                    osaka.utils.LOGGER.debug("Removing specific item {0}".format(item))
                     handle.rm(item)
-                osaka.utils.product_composite_iterator(uri, handle, remove_one,
-                                                       False if handle.isObjectStore() else True)
+
+                osaka.utils.product_composite_iterator(
+                    uri, handle, remove_one, False if handle.isObjectStore() else True
+                )
                 break
             except Exception as e:
                 osaka.utils.LOGGER.warning(
-                    "Exception occurred, retrying({0}): {1}".format(retry+1, e))
+                    "Exception occurred, retrying({0}): {1}".format(retry + 1, e)
+                )
             finally:
                 handle.close()
         else:
             raise
 
     def writeMetrics(self, metrics, output):
-        '''
+        """
         Write out all the metrics
         @param metrics - metrics collected
         @param output - output file
-        '''
-        osaka.utils.LOGGER.info(
-            "Attempting to merge metrics with: {0}".format(output))
+        """
+        osaka.utils.LOGGER.info("Attempting to merge metrics with: {0}".format(output))
         # Rectify metrics
-        metrics["duration"] = (metrics["time_end"] -
-                               metrics["time_start"]).total_seconds()
-        metrics["transfer_rate"] = metrics["size"]/metrics["duration"]
-        metrics["time_start"] = metrics["time_start"].isoformat()+"Z"
-        metrics["time_end"] = metrics["time_end"].isoformat()+"Z"
+        metrics["duration"] = (
+            metrics["time_end"] - metrics["time_start"]
+        ).total_seconds()
+        metrics["transfer_rate"] = metrics["size"] / metrics["duration"]
+        metrics["time_start"] = metrics["time_start"].isoformat() + "Z"
+        metrics["time_end"] = metrics["time_end"].isoformat() + "Z"
         try:
             # Read input data
             data = {}
             if os.path.exists(output):
-                osaka.utils.LOGGER.info(
-                    "Loaded metadata from: {0}".format(output))
+                osaka.utils.LOGGER.info("Loaded metadata from: {0}".format(output))
                 with open(output, "r") as inputf:
                     data = json.load(inputf)
             # Add metric
-            data.setdefault(metrics['type'], []).append(metrics)
+            data.setdefault(metrics["type"], []).append(metrics)
             # Write out the file
             osaka.utils.LOGGER.info("Writing metric to: {0}".format(output))
             with open(output, "w") as outputf:
                 json.dump(data, outputf)
         except Exception as e:
             osaka.utils.LOGGER.warning(
-                "Error merging metrics with: {0} Error: {1}".format(output, str(e)))
+                "Error merging metrics with: {0} Error: {1}".format(output, str(e))
+            )
             raise e

--- a/osaka/transfer.py
+++ b/osaka/transfer.py
@@ -16,7 +16,6 @@ standard_library.install_aliases()
 import os
 import traceback
 import json
-import socket
 import datetime
 
 # Osaka imports
@@ -126,7 +125,7 @@ class Transferer(object):
         # If we never reach the break, reraise the last exception that happened
         else:
             raise err
-        if measure and not metrics is None:
+        if measure and metrics is not None:
             self.writeMetrics(metrics, metricsOutput)
 
     def transfer_uri(self, source, shandle, dest, dhandle):

--- a/osaka/utils.py
+++ b/osaka/utils.py
@@ -6,6 +6,7 @@ from builtins import int
 from builtins import map
 from builtins import str
 from future import standard_library
+
 standard_library.install_aliases()
 import logging
 import subprocess
@@ -13,51 +14,48 @@ import urllib.parse
 
 LOGGER = logging.getLogger("osaka")
 
-DU_CALC = {
-    "GB": 1024**3,
-    "MB": 1024**2,
-    "KB": 1024
-}
+DU_CALC = {"GB": 1024 ** 3, "MB": 1024 ** 2, "KB": 1024}
 
 
 def get_uri_username_and_password(uri):
-    '''
+    """
     Parses the URI and returns the username and password
     @param uri: URI for the end point
     @return: tuple containing the username/password from the URI 
-    '''
+    """
     temp = urllib.parse.urlparse(uri)
     return (temp.username, temp.password)
 
 
 def get_uri_scheme_and_hostname(uri):
-    '''
+    """
     Parses the URI and returns the scheme and hostname
     @param uri: URI for the end point
     @return: tuple containing the scheme/hostname from the URI 
-    '''
+    """
     temp = urllib.parse.urlparse(uri)
-    host = temp.hostname + ("" if temp.port is None else ":"+str(temp.port))
+    host = temp.hostname + ("" if temp.port is None else ":" + str(temp.port))
     return (temp.scheme, host)
 
 
 def get_uri_path(uri):
-    '''
+    """
     Gets the path from the uri
     @param uri: uri from which to parse path
     @return: path portion of URI
-    '''
+    """
     temp = urllib.parse.urlparse(uri)
     return temp.path
 
 
 def get_container_and_path(urlpath):
-    '''
+    """
     Gets the container and path from the given url
     @param urlpath - url's path to determine container and path from
-    '''
+    """
     split = urlpath.lstrip("/").split("/", 1)
     return (split[0], "" if not len(split) > 1 else split[1])
+
 
 # def walk(func, directory,destdir, *params):
 #    '''
@@ -77,26 +75,26 @@ def get_container_and_path(urlpath):
 
 def get_disk_usage(path):
     """Return disk size, "du -sk", for a path."""
-    return int(subprocess.check_output(['du', '-sk', path]).split()[0]) * DU_CALC['KB']
+    return int(subprocess.check_output(["du", "-sk", path]).split()[0]) * DU_CALC["KB"]
 
 
 def human_size(size):
     """Return the human size"""
     for tmp in ["GB", "MB", "KB"]:
         if size > DU_CALC[tmp]:
-            return (size/float(DU_CALC[tmp]), tmp)
+            return (size / float(DU_CALC[tmp]), tmp)
     return (size, "B")
 
 
 def product_composite_iterator(base, handle, callback, include_top=False):
-    '''
+    """
     A function to walk through an osaka product enabling handling of
     coposite childeren. Note: if not a composite product, nothing happens.
     @param base: base of the product
     @param handle: handler for the backend
     @param callback: callback taking uri, and relative path
     @param include_top: include top of composite
-    '''
+    """
     uris = [base]
     if handle.isComposite(base):
         uris = handle.listAllChildren(base)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "six>=1.10.0",
         "configparser>=3.5.0",
         "future>=0.17.1",
+        "backoff>=1.3.1",
     ],
     entry_points={"console_scripts": ["osaka = osaka.__main__:main"]},
 )


### PR DESCRIPTION
- wrapped the call to `obj.load()` in a backoff decorator to handle cases where an uploaded file to S3 doesn't have it's metadata available immediately after
- added unit tests for the s3 storage backend to test the updated functionality
  - mock S3 API using `moto`
- black format everything
- fix flake8 issues
- bump version