### PR TITLE
HC-265: osaka fails to write several file types to another file system

### DIFF
--- a/osaka/storage/file.py
+++ b/osaka/storage/file.py
@@ -64,7 +64,7 @@ class File(osaka.base.StorageBase):
         osaka.utils.LOGGER.debug("Getting stream from URI: {0}".format(uri))
         path = urllib.parse.urlparse(uri).path
         try:
-            fh = open(path, "r")
+            fh = open(path, "rb")
         except FileNotFoundError:
             raise osaka.utils.OsakaFileNotFound("File {} doesn't exist.".format(uri))
         self.files.append(fh)


### PR DESCRIPTION
After reading as binary, osaka can copy all files.