### PR TITLE
HC-315: hotfix to always use SSL S3 endpoint

### DIFF
--- a/osaka/storage/s3.py
+++ b/osaka/storage/s3.py
@@ -67,7 +67,7 @@ class S3(osaka.base.StorageBase):
         """
         osaka.utils.LOGGER.debug("Opening S3 handler")
         self.cache = {}
-        uri = re.compile("^s3").sub("http", uri)
+        uri = re.compile(r'^s3s?').sub("https", uri)
         parsed = urllib.parse.urlparse(uri)
         session_kwargs = {}
         kwargs = {}


### PR DESCRIPTION
In certain edge cases that remain undetermined, osaka will fail to upload an object to s3 with:

```
2021-01-14 18:14:47,094 botocore.hooks [DEBUG] Event needs-retry.s3.UploadPart: calling handler <botocore.retryhandler.RetryHandler object at 0x7f7af211adc0>
2021-01-14 18:14:47,094 botocore.retryhandler [DEBUG] retry needed, retryable exception caught: Connection was closed before we received a valid response from endpoint URL: "http://s3-us-west-2.amazonaws.com/xxxxxx/container-aria-jpl_eonet-event-scraper%3Amain.tar.gz?uploadId=L_mbc8PePVghpktd7uA6fJdoilsYSpBvsgW8dXblzSuJiV1w58gO2ypTx2cqoqHovGgiWMOUnv9.JQf54Uow1AL45oiVV9N2waa_t2KYSrXuSGwiCPjDChmvTUaAONUA&partNumber=1".
Traceback (most recent call last):
  File "/export/home/hysdsops/conda/lib/python3.8/site-packages/urllib3/connectionpool.py", line 670, in urlopen
    httplib_response = self._make_request(
  File "/export/home/hysdsops/conda/lib/python3.8/site-packages/urllib3/connectionpool.py", line 392, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/export/home/hysdsops/conda/lib/python3.8/http/client.py", line 1255, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/export/home/hysdsops/verdi/lib/python3.8/site-packages/botocore/awsrequest.py", line 91, in _send_request
    rval = super(AWSConnection, self)._send_request(
  File "/export/home/hysdsops/conda/lib/python3.8/http/client.py", line 1301, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/export/home/hysdsops/conda/lib/python3.8/http/client.py", line 1250, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/export/home/hysdsops/verdi/lib/python3.8/site-packages/botocore/awsrequest.py", line 126, in _send_output
    self._handle_expect_response(message_body)
  File "/export/home/hysdsops/verdi/lib/python3.8/site-packages/botocore/awsrequest.py", line 169, in _handle_expect_response
    self._send_message_body(message_body)
  File "/export/home/hysdsops/verdi/lib/python3.8/site-packages/botocore/awsrequest.py", line 196, in _send_message_body
    self.send(message_body)
  File "/export/home/hysdsops/verdi/lib/python3.8/site-packages/botocore/awsrequest.py", line 203, in send
    return super(AWSConnection, self).send(str)
  File "/export/home/hysdsops/conda/lib/python3.8/http/client.py", line 968, in send
    self.sock.sendall(datablock)
socket.timeout: timed out
```

After debugging, it was determined that the error can be avoided by always using the HTTPS endpoint, e.g. https://s3-us-west-2.amazonaws.com instead of http://s3-us-west-2.amazonaws.com.
