### PR TITLE
Appending uuid4 to /tmp/osaka-* files

### DIFF
--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"

--- a/osaka/storage/az.py
+++ b/osaka/storage/az.py
@@ -12,6 +12,8 @@ import urllib.parse
 import datetime
 import os.path
 import traceback
+from uuid import uuid4
+
 import osaka.base
 import osaka.utils
 import osaka.storage.file
@@ -101,7 +103,7 @@ class Azure(osaka.base.StorageBase):
         container, key = osaka.utils.get_container_and_path(
             urllib.parse.urlparse(uri).path
         )
-        fname = "/tmp/osaka-azure-" + str(datetime.datetime.now())
+        fname = "/tmp/osaka-azure-%s-%s" % (uuid4(), datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f"))
         with open(fname, "w"):
             pass
         fh = open(fname, "r+b")

--- a/osaka/storage/file.py
+++ b/osaka/storage/file.py
@@ -15,6 +15,7 @@ import shutil
 import os
 import datetime
 import io
+from uuid import uuid4
 
 import osaka.utils
 import osaka.base
@@ -201,8 +202,8 @@ class FileHandlerConversion(object):
         # If the stream is not a file, make a temporary file out of it
         if self.filename is None or not os.path.exists(self.filename):
             self.handler = File()
-            self.filename = "/tmp/osaka-temporary-" + datetime.datetime.utcnow().strftime(
-                "%Y%m%d%H%M%S.%f"
+            self.filename = "/tmp/osaka-temporary-%s-%s" % (
+                uuid4(), datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f")
             )
             self.handler.connect(self.filename)
             self.handler.put(stream, self.filename)

--- a/osaka/storage/ftp.py
+++ b/osaka/storage/ftp.py
@@ -15,6 +15,8 @@ import urllib.parse
 import datetime
 import os.path
 import traceback
+from uuid import uuid4
+
 import osaka.base
 import osaka.utils
 import osaka.storage.file
@@ -69,7 +71,7 @@ class FTP(osaka.base.StorageBase):
         """
         osaka.utils.LOGGER.debug("Getting stream from URI: {0}".format(uri))
         filename = urllib.parse.urlparse(uri).path
-        fname = "/tmp/osaka-ftp-" + str(datetime.datetime.now())
+        fname = "/tmp/osaka-ftp-%s-%s" % (uuid4(), datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f"))
         try:
             with open(fname, "w") as tmpf:
                 self.ftp.retrbinary("RETR %s" % filename, tmpf.write)

--- a/osaka/storage/s3.py
+++ b/osaka/storage/s3.py
@@ -19,6 +19,8 @@ import urllib.parse
 import datetime
 import os.path
 import json
+from uuid import uuid4
+
 import osaka.base
 import osaka.utils
 import osaka.storage.file
@@ -180,7 +182,7 @@ class S3(osaka.base.StorageBase):
         container, key = osaka.utils.get_s3_container_and_path(uri, is_nominal_style=self.is_nominal_style)
         bucket = self.bucket(container, create=False)
         obj = bucket.Object(key)
-        fname = "/tmp/osaka-s3-" + str(datetime.datetime.now())
+        fname = "/tmp/osaka-s3-%s-%s" % (uuid4(), datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f"))
         with open(fname, "w"):
             pass
         fh = open(fname, "r+b")

--- a/osaka/transfer.py
+++ b/osaka/transfer.py
@@ -132,6 +132,10 @@ class Transferer(object):
     def transfer_uri(self, source, shandle, dest, dhandle):
         """
         Transfer a URI recursing into it if it is a composite
+        @param source: Str
+        @param shandle: osaka.storage class instance (source)
+        @param dest: Str
+        @param dhandle: osaka.storage class instance (destination)
         """
         metrics = {
             "source": source,


### PR DESCRIPTION
related ticket(s):
- https://jira.jpl.nasa.gov/browse/NSDS-2783

when parallelizing dataset publish it causes a race condition with the temporary files created by osaka:
```
Traceback (most recent call last):
  File "/home/ops/verdi/ops/hysds-1.2.3/hysds/job_worker.py", line 1410, in run_job
    post_processor_sigs.append(func(job, context))
  File "/home/ops/verdi/ops/hysds-1.2.3/hysds/dataset_ingest_bulk.py", line 950, in publish_datasets
    raise NotAllProductsIngested("Product failed to ingest to data store: {}".format(err))
hysds.dataset_ingest_bulk.NotAllProductsIngested: Product failed to ingest to data store: Traceback (most recent call last):
  File "/home/ops/verdi/lib/python3.9/site-packages/billiard/pool.py", line 362, in workloop
    result = (True, prepare_result(fun(*args, **kwargs)))
  File "/home/ops/verdi/ops/hysds-1.2.3/hysds/dataset_ingest_bulk.py", line 817, in async_publish_files
    metrics, prod_json = ingest_to_object_store(
  File "/home/ops/verdi/ops/hysds-1.2.3/hysds/dataset_ingest_bulk.py", line 406, in ingest_to_object_store
    write_to_object_store(
  File "/home/ops/verdi/ops/hysds-1.2.3/hysds/dataset_ingest_bulk.py", line 192, in write_to_object_store
    osaka.main.put(abs_path, dest_url, params=params, noclobber=True)
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/main.py", line 38, in put
    transfer(
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/main.py", line 118, in transfer
    transfer.transfer(
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/transfer.py", line 128, in transfer
    raise err
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/transfer.py", line 104, in transfer
    with osaka.cooperator.Cooperator(source, dlock, lockMetadata) as coop:
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/cooperator.py", line 38, in __enter__
    self.dlock.lock(lockMetadata)
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/lock.py", line 79, in lock
    handle.put(stream, self.luri)
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/storage/s3.py", line 214, in put
    obj.upload_file(fn, ExtraArgs=extra)
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/storage/file.py", line 224, in __exit__
    self.handler.rm(self.filename)
  File "/home/ops/verdi/ops/osaka-1.2.1/osaka/storage/file.py", line 185, in rm
    os.remove(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/osaka-temporary-20230425223144.838790'
```

adding a uuid (v4) to the `/tmp/osaka-*` file to prevent collision
ex. `/tmp/osaka-temporary-20230425223144.838790` -> `/tmp/osaka-temporary-e90d9905-3e6f-4875-8ea7-0f109b053908-20230426180722.965226`