### PR TITLE
HC-475 - Cache the boto3 session in the osaka S3 storage class

### DIFF
--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-475

change(s):
- bump version
- storing the boto3 session and credential objects in the osaka class variable after the `connect()` method is called
  - if using IAM role the session will then re-used if the credentials have not expired
  - IAM role means the credentials object is a `RefreshableCredentials` class which has a method called `refresh_needed()`
  - the `refresh_needed()` method is not provided if credentials are found elsewhere, like `~/.aws/credentials`

when testing on `SCIFLO_L0A_TE` (`SIT_DIL`) job, publishing went from ~10 hours to ~40 minutes

```python
>>> src = "/export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat"
>>> dest = "s3://nisar-dev-es-bucket/test-parallel/fake_data.dat"
>>> osaka.main.put(src, dest)
INFO:osaka:Running backwards-compatible 'Osaka Put' from /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat to s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
INFO:osaka:Running new-style 'Osaka Transfer' from /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat to s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
INFO:osaka:Opening connections for /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat and s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
INFO:botocore.credentials:Found credentials from IAM Role: am-pcm-cluster-role
INFO:osaka:Making session with: {"region_name": "us-west-2"}  # <----- SESSION CREATED HERE, WILL BE RE-USED
INFO:botocore.credentials:Found credentials from IAM Role: am-pcm-cluster-role  # # <----- CREDENTIALS FOUND HERE, WILL BE RE-USED IF NOT EXPIRED
INFO:osaka:Checking lock status of /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat in /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat.osaka.locked.json
INFO:osaka:Transferring between /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat and s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
>>>

# no session or credentials logs, means the session has been re-used when called again
>>> osaka.main.put(src, dest)
INFO:osaka:Running backwards-compatible 'Osaka Put' from /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat to s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
INFO:osaka:Running new-style 'Osaka Transfer' from /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat to s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
INFO:osaka:Opening connections for /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat and s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
INFO:osaka:Checking lock status of /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat in /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat.osaka.locked.json
INFO:osaka:Transferring between /export/home/hysdsops/output/hello_world-product-20230601T001122.100679424Z-7f329/fake_data.dat and s3://nisar-dev-es-bucket/test-parallel/fake_data.dat
```
