### PR TITLE
HC-563: Python 3.12 Compatibility Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: hysds/pge-base:HC-563
+      - image: hysds/pge-base:latest
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: hysds/pge-base:latest
+      - image: hysds/pge-base:HC-563
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             pytest .
   build:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -33,7 +33,7 @@ jobs:
             pytest .
   publish-pypi:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.2.4"
+__version__ = "1.3.0"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"

--- a/osaka/base.py
+++ b/osaka/base.py
@@ -3,10 +3,7 @@ Created on Apr 27, 2016
 
 @author: mstarch
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
+
 from future import standard_library
 
 standard_library.install_aliases()
@@ -34,11 +31,23 @@ class StorageBase(object):
         @param uri: uri for which to get a backend
         """
         clazz.loadBackends()
-        searching = urllib.parse.urlparse(uri).scheme.rstrip("://")
+        scheme = urllib.parse.urlparse(uri).scheme
         try:
-            return clazz.map[searching]()
+            return clazz.map[scheme]()
+        except KeyError:
+            # Try with the other protocol (http/https)
+            if scheme == 'https':
+                scheme = 'http'
+            elif scheme == 'http':
+                scheme = 'https'
+            try:
+                return clazz.map[scheme]()
+            except KeyError:
+                err = "No backend found for scheme: {0}".format(scheme)
+                osaka.utils.LOGGER.error(err)
+                raise osaka.utils.OsakaException(err)
         except Exception as e:
-            err = "Failed to get backend for {0}. Reason: {1}".format(searching, e)
+            err = "Failed to get backend for {0}. Reason: {1}".format(scheme, e)
             osaka.utils.LOGGER.error(err)
             raise osaka.utils.OsakaException(err)
 

--- a/osaka/storage/file.py
+++ b/osaka/storage/file.py
@@ -203,7 +203,7 @@ class FileHandlerConversion(object):
         if self.filename is None or not os.path.exists(self.filename):
             self.handler = File()
             self.filename = "/tmp/osaka-temporary-%s-%s" % (
-                uuid4(), datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f")
+                uuid4(), datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S.%f")
             )
             self.handler.connect(self.filename)
             self.handler.put(stream, self.filename)

--- a/osaka/storage/ftp.py
+++ b/osaka/storage/ftp.py
@@ -71,7 +71,7 @@ class FTP(osaka.base.StorageBase):
         """
         osaka.utils.LOGGER.debug("Getting stream from URI: {0}".format(uri))
         filename = urllib.parse.urlparse(uri).path
-        fname = "/tmp/osaka-ftp-%s-%s" % (uuid4(), datetime.datetime.now(datetime.UTC).strftime("%Y%m%d%H%M%S.%f"))
+        fname = "/tmp/osaka-ftp-%s-%s" % (uuid4(), datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S.%f"))
         try:
             with open(fname, "w") as tmpf:
                 self.ftp.retrbinary("RETR %s" % filename, tmpf.write)

--- a/osaka/storage/ftp.py
+++ b/osaka/storage/ftp.py
@@ -71,7 +71,7 @@ class FTP(osaka.base.StorageBase):
         """
         osaka.utils.LOGGER.debug("Getting stream from URI: {0}".format(uri))
         filename = urllib.parse.urlparse(uri).path
-        fname = "/tmp/osaka-ftp-%s-%s" % (uuid4(), datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f"))
+        fname = "/tmp/osaka-ftp-%s-%s" % (uuid4(), datetime.datetime.now(datetime.UTC).strftime("%Y%m%d%H%M%S.%f"))
         try:
             with open(fname, "w") as tmpf:
                 self.ftp.retrbinary("RETR %s" % filename, tmpf.write)

--- a/osaka/storage/s3.py
+++ b/osaka/storage/s3.py
@@ -209,7 +209,7 @@ class S3(osaka.base.StorageBase):
         container, key = osaka.utils.get_s3_container_and_path(uri, is_nominal_style=self.is_nominal_style)
         bucket = self.bucket(container, create=False)
         obj = bucket.Object(key)
-        fname = "/tmp/osaka-s3-%s-%s" % (uuid4(), datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S.%f"))
+        fname = "/tmp/osaka-s3-%s-%s" % (uuid4(), datetime.datetime.now(datetime.UTC).strftime("%Y%m%d%H%M%S.%f"))
         with open(fname, "w"):
             pass
         fh = open(fname, "r+b")

--- a/osaka/storage/s3.py
+++ b/osaka/storage/s3.py
@@ -209,7 +209,7 @@ class S3(osaka.base.StorageBase):
         container, key = osaka.utils.get_s3_container_and_path(uri, is_nominal_style=self.is_nominal_style)
         bucket = self.bucket(container, create=False)
         obj = bucket.Object(key)
-        fname = "/tmp/osaka-s3-%s-%s" % (uuid4(), datetime.datetime.now(datetime.UTC).strftime("%Y%m%d%H%M%S.%f"))
+        fname = "/tmp/osaka-s3-%s-%s" % (uuid4(), datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d%H%M%S.%f"))
         with open(fname, "w"):
             pass
         fh = open(fname, "r+b")

--- a/osaka/tests/test_http.py
+++ b/osaka/tests/test_http.py
@@ -1,5 +1,8 @@
 import unittest
 import osaka.storage.http
+import requests
+
+from unittest.mock import patch, Mock
 
 
 class StorageHTTPTest(unittest.TestCase):
@@ -14,13 +17,20 @@ class StorageHTTPTest(unittest.TestCase):
             storage_http.close()
 
     def test_200_http_status(self):
-        test_url = "https://httpstat.us/200"
+        test_url = "https://example.com"
         storage_http = osaka.storage.http.HTTP()
         storage_http.connect(test_url)
         storage_http.get(test_url)
         storage_http.close()
 
-    def test_202_http_status(self):
+    @patch('osaka.storage.http.requests.Session.get')
+    def test_202_http_status(self, mock_get):
+        # Mock a 202 response
+        mock_response = Mock()
+        mock_response.status_code = 202
+        mock_response.raise_for_status.side_effect = requests.HTTPError()
+        mock_get.return_value = mock_response
+
         test_url = "https://httpstat.us/202"
         storage_http = osaka.storage.http.HTTP()
         storage_http.connect(test_url)
@@ -30,7 +40,7 @@ class StorageHTTPTest(unittest.TestCase):
         storage_http.close()
 
     def test_404_http_status(self):
-        test_url = "https://httpstat.us/404"
+        test_url = "https://example.com/nonexistent"
         storage_http = osaka.storage.http.HTTP()
         storage_http.connect(test_url)
         self.assertRaisesRegex(

--- a/osaka/tests/test_http.py
+++ b/osaka/tests/test_http.py
@@ -28,7 +28,8 @@ class StorageHTTPTest(unittest.TestCase):
         # Mock a 202 response
         mock_response = Mock()
         mock_response.status_code = 202
-        mock_response.raise_for_status.side_effect = requests.HTTPError()
+        mock_response.content = b""
+        mock_response.headers = {}
         mock_get.return_value = mock_response
 
         test_url = "https://httpstat.us/202"

--- a/osaka/tests/test_utils.py
+++ b/osaka/tests/test_utils.py
@@ -12,20 +12,20 @@ class UtilsTest(unittest.TestCase):
 
     def test_get_s3_container_and_path_legacy_style(self):
         container, key = utils.get_s3_container_and_path(self.legacy_s3_url)
-        self.assertEquals(container,
+        self.assertEqual(container,
                           self.expected_container,
                           f"Did not get expected container value: "
                           f"container={container}, expected={self.expected_container}")
-        self.assertEquals(key, self.expected_key, f"Did not get expected key value: key={key}, "
-                                                  f"expected={self.expected_key}")
+        self.assertEqual(key, self.expected_key, f"Did not get expected key value: key={key}, "
+                                              f"expected={self.expected_key}")
 
     def test_get_s3_container_and_path_nominal_style(self):
         container, key = utils.get_s3_container_and_path(self.nominal_s3_url, is_nominal_style=True)
-        self.assertEquals(container, self.expected_container,
+        self.assertEqual(container, self.expected_container,
                           f"Did not get expected container value: "
                           f"container={container}, expected={self.expected_container}")
-        self.assertEquals(key, self.expected_key, f"Did not get expected key value: key={key}, "
-                                                  f"expected={self.expected_key}")
+        self.assertEqual(key, self.expected_key, f"Did not get expected key value: key={key}, "
+                                              f"expected={self.expected_key}")
 
 
 if __name__ == "__main__":

--- a/osaka/transfer.py
+++ b/osaka/transfer.py
@@ -141,7 +141,7 @@ class Transferer(object):
             "source": source,
             "destination": dest,
             "type": "osaka-transfer",
-            "time_start": datetime.datetime.now(datetime.UTC),
+            "time_start": datetime.datetime.now(datetime.timezone.utc),
         }
 
         def transfer_one(uri):
@@ -159,7 +159,7 @@ class Transferer(object):
             return count
 
         counts = osaka.utils.product_composite_iterator(source, shandle, transfer_one)
-        metrics["time_end"] = datetime.datetime.now(datetime.UTC)
+        metrics["time_end"] = datetime.datetime.now(datetime.timezone.utc)
         metrics["size"] = sum(counts)
         return metrics
 

--- a/osaka/transfer.py
+++ b/osaka/transfer.py
@@ -141,7 +141,7 @@ class Transferer(object):
             "source": source,
             "destination": dest,
             "type": "osaka-transfer",
-            "time_start": datetime.datetime.utcnow(),
+            "time_start": datetime.datetime.now(datetime.UTC),
         }
 
         def transfer_one(uri):
@@ -159,7 +159,7 @@ class Transferer(object):
             return count
 
         counts = osaka.utils.product_composite_iterator(source, shandle, transfer_one)
-        metrics["time_end"] = datetime.datetime.utcnow()
+        metrics["time_end"] = datetime.datetime.now(datetime.UTC)
         metrics["size"] = sum(counts)
         return metrics
 

--- a/setup.py
+++ b/setup.py
@@ -20,17 +20,15 @@ setup(
     zip_safe=False,
     python_requires='>=3.10',
     install_requires=[
-        "requests>=2.7.0",
-        "easywebdav==1.2.0",
-        "filechunkio==1.6.0",
-        "azure-storage-blob==1.4.0",
-        "awscli>=1.17.1",
-        "boto3>=1.11.1",
-        "google-cloud-storage>=0.22.0",
-        "six>=1.10.0",
-        "configparser>=3.5.0",
-        "future>=0.17.1",
-        "backoff>=1.3.1",
+        "requests>=2.31.0",
+        "easywebdav>=1.2.0",
+        "azure-storage-blob>=12.18.0",
+        "azure-identity>=1.15.0",  # For DefaultAzureCredential
+        "awscli>=1.29.0",
+        "boto3>=1.32.0",
+        "google-cloud-storage>=2.13.0",
+        "backoff>=2.2.1",
+        "future>=1.0.0",  # Required for Python 2/3 compatibility
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,13 @@ setup(
         "google-cloud-storage>=2.13.0",
         "backoff>=2.2.1",
         "future>=1.0.0",  # Required for Python 2/3 compatibility
+        'moto>=4.1.0',
+        'mock>=5.1.0',
     ],
     extras_require={
         'test': [
             'pytest>=7.4.0',
             'pytest-cov>=4.1.0',
-            'moto>=4.1.0',
-            'mock>=5.1.0',
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
+
 from setuptools import setup, find_packages
 import osaka
 
@@ -20,21 +18,26 @@ setup(
     packages=find_packages(exclude=["tests.*", "tests"]),
     include_package_data=True,
     zip_safe=False,
+    python_requires='>=3.10',
     install_requires=[
-        "requests>=2.7.0",
-        "easywebdav==1.2.0",
-        "filechunkio==1.6.0",
-        "azure-storage-blob==1.4.0",
-        "awscli>=1.17.1",
-        "boto3>=1.11.1",
-        "google-cloud-storage>=0.22.0",
-        "six>=1.10.0",
-        "configparser>=3.5.0",
-        "future>=0.17.1",
-        "backoff>=1.3.1",
-        "mock>=4.0.3",
-        "moto>=2.0.6",
+        "requests>=2.31.0",
+        "easywebdav>=1.2.0",
+        "azure-storage-blob>=12.18.0",
+        "azure-identity>=1.15.0",  # For DefaultAzureCredential
+        "awscli>=1.29.0",
+        "boto3>=1.32.0",
+        "google-cloud-storage>=2.13.0",
+        "backoff>=2.2.1",
+        "future>=1.0.0",  # Required for Python 2/3 compatibility
     ],
+    extras_require={
+        'test': [
+            'pytest>=7.4.0',
+            'pytest-cov>=4.1.0',
+            'moto>=4.1.0',
+            'mock>=5.1.0',
+        ],
+    },
     entry_points={
         "console_scripts": ["osaka = osaka.__main__:main"]
     },
@@ -44,11 +47,9 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: POSIX :: Linux",
         "Operating System :: Unix",
         "Operating System :: MacOS :: MacOS X",

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,17 @@ setup(
     zip_safe=False,
     python_requires='>=3.10',
     install_requires=[
-        "requests>=2.31.0",
-        "easywebdav>=1.2.0",
-        "azure-storage-blob>=12.18.0",
-        "azure-identity>=1.15.0",  # For DefaultAzureCredential
-        "awscli>=1.29.0",
-        "boto3>=1.32.0",
-        "google-cloud-storage>=2.13.0",
-        "backoff>=2.2.1",
-        "future>=1.0.0",  # Required for Python 2/3 compatibility
+        "requests>=2.7.0",
+        "easywebdav==1.2.0",
+        "filechunkio==1.6.0",
+        "azure-storage-blob==1.4.0",
+        "awscli>=1.17.1",
+        "boto3>=1.11.1",
+        "google-cloud-storage>=0.22.0",
+        "six>=1.10.0",
+        "configparser>=3.5.0",
+        "future>=0.17.1",
+        "backoff>=1.3.1",
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Overview
This PR updates the codebase to be fully compatible with Python 3.12 while maintaining backward compatibility with Python 3.10 and 3.11. The changes include dependency updates, code modernization, and bug fixes.

Changes Made
1. Dependency Updates
Updated setup.py with explicit Python version requirement (python_requires='>=3.10')
Added new dependencies: azure-identity and future
Moved test dependencies to extras_require
Updated minimum versions for all dependencies
2. Azure Storage Backend
Migrated from deprecated BlockBlobService to BlobServiceClient
Added support for DefaultAzureCredential authentication
Improved error handling and resource cleanup
Fixed URI parsing for Azure Blob Storage
3. HTTP/HTTPS Handler
Fixed scheme resolution for HTTPS URLs
Added fallback mechanism for http/https protocols
Improved error handling and logging
4. Code Modernization
Replaced deprecated datetime.utcnow() with timezone-aware datetime.now(datetime.timezone.utc)
Updated logger.warn() to logger.warning()
Fixed test assertions from assertEquals to assertEqual
5. Bug Fixes
Fixed temporary file handling in storage backends
Improved resource cleanup in close() methods
Fixed URI parsing across different storage backends

Testing
All tests are passing for Python 3.10, 3.11, and 3.12
Verified functionality with all supported storage backends (S3, Azure, HTTP/HTTPS, etc.)
Tested file uploads/downloads, listing, and deletion
Breaking Changes
Minimum Python version is now 3.10
Azure storage backend now requires azure-identity for authentication