### PR TITLE
Fix HC-589: Add dynamic S3 bucket region detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+.claude/

--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"

--- a/osaka/tests/test_s3.py
+++ b/osaka/tests/test_s3.py
@@ -96,7 +96,7 @@ class StorageS3Test(unittest.TestCase):
 
     @mock_aws
     def test_s3_eventual_consistency_handling(self):
-        """Test exponential backoff works to retry object metadata reload for some time and 
+        """Test exponential backoff works to retry object metadata reload for some time and
            eventually succeeds."""
 
         self.s3.create_bucket(
@@ -115,3 +115,171 @@ class StorageS3Test(unittest.TestCase):
             assert (
                 obj["Body"].read().decode() == "test_s3_eventual_consistency_handling"
             )
+
+    @mock_aws
+    def test_s3_cross_region_bucket_access(self):
+        """Test that osaka can detect and handle buckets in different regions."""
+
+        # Create buckets in different regions
+        s3_west = boto3.client("s3", region_name="us-west-2")
+        s3_west.create_bucket(
+            Bucket="west-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+        s3_west.put_object(
+            Bucket="west-bucket", Key="test.txt", Body="west data"
+        )
+
+        s3_east = boto3.client("s3", region_name="us-east-1")
+        s3_east.create_bucket(Bucket="east-bucket")
+        s3_east.put_object(
+            Bucket="east-bucket", Key="test.txt", Body="east data"
+        )
+
+        # Test accessing west bucket with nominal-style URL
+        storage_s3 = osaka.storage.s3.S3()
+        west_url = "s3://west-bucket/test.txt"
+        storage_s3.connect(west_url, params={"aws_access_key_id": "test", "aws_secret_access_key": "test"})
+
+        # Verify region cache is populated
+        assert "west-bucket" in storage_s3.region_cache
+        assert storage_s3.region_cache["west-bucket"] == "us-west-2"
+
+        fh = storage_s3.get(west_url)
+        assert fh.read().decode() == "west data"
+
+        # Test accessing east bucket with nominal-style URL
+        east_url = "s3://east-bucket/test.txt"
+        storage_s3_east = osaka.storage.s3.S3()
+        storage_s3_east.connect(east_url, params={"aws_access_key_id": "test", "aws_secret_access_key": "test"})
+
+        # Verify region cache is populated
+        assert "east-bucket" in storage_s3_east.region_cache
+        assert storage_s3_east.region_cache["east-bucket"] == "us-east-1"
+
+        fh_east = storage_s3_east.get(east_url)
+        assert fh_east.read().decode() == "east data"
+
+        storage_s3.close()
+        storage_s3_east.close()
+
+    @mock_aws
+    def test_s3_virtual_hosted_style_url(self):
+        """Test that osaka handles virtual-hosted style URLs correctly."""
+
+        # Create bucket in us-west-2
+        s3_west = boto3.client("s3", region_name="us-west-2")
+        s3_west.create_bucket(
+            Bucket="test-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+        s3_west.put_object(
+            Bucket="test-bucket", Key="data.txt", Body="virtual hosted data"
+        )
+
+        # Test accessing with virtual-hosted style URL (region in hostname)
+        storage_s3 = osaka.storage.s3.S3()
+        virtual_hosted_url = "s3://s3.us-west-2.amazonaws.com/test-bucket/data.txt"
+        storage_s3.connect(virtual_hosted_url)
+
+        # This should use the region from the URL, not attempt detection
+        assert storage_s3.is_nominal_style == False
+
+        fh = storage_s3.get(virtual_hosted_url)
+        assert fh.read().decode() == "virtual hosted data"
+
+        storage_s3.close()
+
+    @mock_aws
+    def test_s3_legacy_style_url_with_port(self):
+        """Test that osaka handles URLs with port correctly."""
+
+        # Create bucket in us-west-2
+        s3_west = boto3.client("s3", region_name="us-west-2")
+        s3_west.create_bucket(
+            Bucket="legacy-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+        s3_west.put_object(
+            Bucket="legacy-bucket", Key="legacy.txt", Body="legacy data"
+        )
+
+        # Test accessing with URL that includes port
+        storage_s3 = osaka.storage.s3.S3()
+        legacy_url = "s3://s3.us-west-2.amazonaws.com:80/legacy-bucket/legacy.txt"
+        storage_s3.connect(legacy_url)
+
+        # This should use the region from the URL
+        assert storage_s3.is_nominal_style == False
+
+        fh = storage_s3.get(legacy_url)
+        assert fh.read().decode() == "legacy data"
+
+        storage_s3.close()
+
+    @mock_aws
+    def test_s3_secure_url_variant(self):
+        """Test that osaka handles s3s:// (secure) URLs correctly."""
+
+        # Create bucket in us-west-2
+        s3_west = boto3.client("s3", region_name="us-west-2")
+        s3_west.create_bucket(
+            Bucket="secure-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+        s3_west.put_object(
+            Bucket="secure-bucket", Key="secure.txt", Body="secure data"
+        )
+
+        # Test accessing with s3s:// nominal style URL
+        storage_s3 = osaka.storage.s3.S3()
+        secure_url = "s3s://secure-bucket/secure.txt"
+        storage_s3.connect(secure_url, params={"aws_access_key_id": "test", "aws_secret_access_key": "test"})
+
+        # Should be treated as nominal style and detect region
+        assert storage_s3.is_nominal_style == True
+        assert "secure-bucket" in storage_s3.region_cache
+        assert storage_s3.region_cache["secure-bucket"] == "us-west-2"
+
+        fh = storage_s3.get(secure_url)
+        assert fh.read().decode() == "secure data"
+
+        storage_s3.close()
+
+    @mock_aws
+    def test_s3_ensure_correct_region_fixes_wrong_endpoint(self):
+        """Test that ensure_correct_region() corrects mismatched region in URL."""
+
+        # Create bucket in us-west-2
+        s3_west = boto3.client("s3", region_name="us-west-2")
+        s3_west.create_bucket(
+            Bucket="west-only-bucket",
+            CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
+        )
+        s3_west.put_object(
+            Bucket="west-only-bucket", Key="data.txt", Body="west region data"
+        )
+
+        # Connect using eu-west-1 endpoint URL (WRONG region for this bucket)
+        # The bucket() method should detect and switch to the correct region
+        storage_s3 = osaka.storage.s3.S3()
+        wrong_region_url = "s3://s3.eu-west-1.amazonaws.com/west-only-bucket/data.txt"
+        storage_s3.connect(wrong_region_url)
+
+        # Initially connected to eu-west-1 from URL
+        assert storage_s3.is_nominal_style == False
+        initial_region = storage_s3.s3.meta.client.meta.region_name
+        assert initial_region == "eu-west-1"
+
+        # When we access the bucket, ensure_correct_region() should fix it
+        fh = storage_s3.get(wrong_region_url)
+        assert fh.read().decode() == "west region data"
+
+        # Verify the region cache was updated
+        assert "west-only-bucket" in storage_s3.region_cache
+        assert storage_s3.region_cache["west-only-bucket"] == "us-west-2"
+
+        # Verify the S3 client switched to the correct region
+        assert storage_s3.s3.meta.client.meta.region_name == "us-west-2"
+
+        storage_s3.close()


### PR DESCRIPTION
## Summary

This PR implements dynamic S3 bucket region detection to resolve issues where nominal-style S3 URLs (`s3://bucket-name/key`) would fail when the bucket is in a different region than the default AWS config region.

## Changes

### Core Implementation ([osaka/storage/s3.py](osaka/storage/s3.py))

1. **Added `region_cache`** - Instance variable to cache detected bucket regions and avoid repeated API calls
2. **Added `get_bucket_region()` static method** - Detects bucket region using:
   - `head_bucket` API (checks `x-amz-bucket-region` header)
   - Fallback to `get_bucket_location` API
   - Handles us-east-1 special case (returns None for LocationConstraint)
3. **Added `ensure_correct_region()` method** - Ensures S3 client uses the correct region:
   - Checks region cache first
   - Detects region if not cached
   - Switches S3 client to correct region if mismatch detected
4. **Modified `connect()` method** - For nominal-style URLs:
   - Extracts bucket name from URI
   - Detects bucket's actual region before creating client
   - Uses detected region with fallback to default
   - Caches detected region for future use
5. **Modified `bucket()` method** - Calls `ensure_correct_region()` before any bucket operations
6. **Fixed bucket creation logic** - Uses client's actual region instead of parsing hostname

### Comprehensive Test Coverage ([osaka/tests/test_s3.py](osaka/tests/test_s3.py))

Added 5 new tests covering all S3 URL formats:

| Test | Description |
|------|-------------|
| `test_s3_cross_region_bucket_access` | Nominal-style URLs with buckets in different regions |
| `test_s3_virtual_hosted_style_url` | Virtual-hosted style URL handling (`s3://s3.region.amazonaws.com/bucket/key`) |
| `test_s3_legacy_style_url_with_port` | URLs with port numbers |
| `test_s3_secure_url_variant` | s3s:// secure URL variants |
| `test_s3_ensure_correct_region_fixes_wrong_endpoint` | Region mismatch correction (URL points to wrong region) |

## Supported S3 URL Formats

All S3 URL formats now work correctly with automatic region detection:

| URL Format | Example | Status |
|------------|---------|--------|
| **Nominal style** | `s3://bucket-name/path/file.txt` | ✅ Region detected dynamically |
| **Virtual-hosted style** | `s3://s3.us-west-2.amazonaws.com/bucket/file.txt` | ✅ Uses region from URL |
| **With port** | `s3://s3.us-west-2.amazonaws.com:80/bucket/file.txt` | ✅ Works correctly |
| **Secure (s3s://)** | `s3s://bucket-name/file.txt` | ✅ All variants work |
| **Wrong region URL** | Using wrong endpoint for bucket | ✅ Auto-corrected |

## Test Results

```bash
$ pytest osaka/tests/test_s3.py -v

============================= test session starts ==============================
osaka/tests/test_s3.py::StorageS3Test::test_s3_cross_region_bucket_access PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_ensure_correct_region_fixes_wrong_endpoint PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_eventual_consistency_error PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_eventual_consistency_handling PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_get PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_legacy_style_url_with_port PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_put PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_secure_url_variant PASSED
osaka/tests/test_s3.py::StorageS3Test::test_s3_virtual_hosted_style_url PASSED

============================== 9 passed in 33.99s =======================================
```

✅ All tests pass

## How It Works

### For Nominal-Style URLs (`s3://bucket-name/file.txt`):
1. Extracts bucket name from URL
2. Calls `get_bucket_region()` to detect actual region via AWS API
3. Caches the detected region
4. Creates S3 client with correct region

### For Virtual-Hosted/Legacy URLs (`s3://s3.region.amazonaws.com/bucket/file.txt`):
1. Extracts region from hostname
2. Uses that region for S3 client
3. `ensure_correct_region()` provides safety net if URL has wrong region

### Region Caching:
- Avoids repeated API calls for the same bucket
- Persists for the lifetime of the S3 storage object

## Resolves

HC-589