### PR TITLE
HC-624: Fix HTTP downloads writing gzip-compressed bytes instead of decoded content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
           name: Test
           command: |
             source $HOME/.bash_profile
+            pip install pytest==7.2.0
             pip install -e .
             pytest .
   build:

--- a/osaka/__init__.py
+++ b/osaka/__init__.py
@@ -3,6 +3,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __url__ = "https://github.com/hysds/osaka"
 __description__ = "Osaka (Object Store Abstraction K Arcitecture)"

--- a/osaka/storage/http.py
+++ b/osaka/storage/http.py
@@ -111,6 +111,7 @@ class HTTP(osaka.base.StorageBase):
 
         if text:
             return response.text
+        response.raw.decode_content = True
         return response.raw
 
     def put(self, stream, uri):


### PR DESCRIPTION
## Summary
- HTTP downloads via `osaka.main.get()` were saving raw gzip-compressed bytes to disk when the server responded with `Content-Encoding: gzip`, resulting in unusable files
- Set `response.raw.decode_content = True` in `HTTP.get()` so urllib3 decompresses content-encoded responses before streaming to disk
- Fully backwards compatible: only decompresses when `Content-Encoding` header is present; binary files without that header are unaffected

## Test plan
- [x] All 17 existing tests pass
- [x] Manual verification: downloaded GeoJSON file now starts with valid JSON (`{"type":"FeatureCollection"...}`) instead of gzip magic bytes (`\x1f\x8b`)